### PR TITLE
fix shatter panic and spelling mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For the rest, there's this [video](https://youtu.be/c5lakP_V1n0).
 ### Brushes
 Brushes are convex polygonal surfaces. They can have an associated texture which can either be drawn filling their area or as a sprite. The sprite can be displaced independently of the brush surface.  
 Brushes can also be assigned a path that describes how it moves in the bidimensional space and that can be edited with the Path tool.  
-Finally, brushes have a built-in property, `collision`, which determines whever they should represent a clipping surface or not. It can be edited in the properties window.
+Finally, brushes have a built-in property, `collision`, which determines whether they should represent a clipping surface or not. It can be edited in the properties window.
 
 ### Things
 Things are objects which can be placed around the map. They area characterized by an ID, a width and height, a name, and a texture which represents them.  
@@ -42,7 +42,7 @@ Such values can be inserted through the `brush_properties` and `thing_properties
 Properties can be edited per-entity using the properties window.   
 Currently supported value types are `bool`, `u8`, `u16`, `u32`, `u64`, `u128`, `i8`, `i16`, `i32`, `i64`, `i128`, `f32`, `f64`, and `String`.   
    
-!!! If a saved map contains properties that differ in type and/or name from the ones defined in the aforementioned resources, a warning window will appear on screen when trying to load the .hv file, asking whever you'd like to use the app or map ones.   
+!!! If a saved map contains properties that differ in type and/or name from the ones defined in the aforementioned resources, a warning window will appear on screen when trying to load the .hv file, asking whether you'd like to use the app or map ones.   
 
 ### Textures
 Textures must be placed in the `assets/textures/` folder to be loaded.  
@@ -138,7 +138,7 @@ The executable can be picked through Options->Exporter.
 HV has been thoroughly tested but is still in its early releases, so there might be issues that lead to crashes due to unrecoverable errors. It is strongly recommended to save often.
 
 ## Known issues
-On Windows, the things and props gallery of the Thing and Paint tools are incorretly drawn. This does not occur on Linux.
+On Windows, the things and props gallery of the Thing and Paint tools are incorrectly drawn. This does not occur on Linux.
 
 ## Misc
 In order to close the in-editor windows through the keyboard the F4 key needs to be pressed (similar to pressing Alt+F4 to close OS windows).

--- a/hill_vacuum_lib/proc_macros/src/lib.rs
+++ b/hill_vacuum_lib/proc_macros/src/lib.rs
@@ -25,7 +25,7 @@ use shared::{
 //
 //=======================================================================//
 
-/// Checks whever `value` is a comma.
+/// Checks whether `value` is a comma.
 /// # Panics
 /// Function panics if `value` is not a comma.
 #[inline]

--- a/hill_vacuum_lib/src/config/controls/bind.rs
+++ b/hill_vacuum_lib/src/config/controls/bind.rs
@@ -119,7 +119,7 @@ impl Bind
         }
     }
 
-    /// Whever the `KeyCode` associated with this has just been pressed.
+    /// Whether the `KeyCode` associated with this has just been pressed.
     #[inline]
     #[must_use]
     pub fn just_pressed(self, key_inputs: &ButtonInput<KeyCode>, binds: &BindsKeyCodes) -> bool
@@ -148,7 +148,7 @@ impl Bind
         self.just_pressed(key_inputs, binds)
     }
 
-    /// Returns true whever `value` can be assigned to a `Bind`.
+    /// Returns true whether `value` can be assigned to a `Bind`.
     #[inline]
     #[must_use]
     fn is_keycode_legal(value: KeyCode) -> bool

--- a/hill_vacuum_lib/src/lib.rs
+++ b/hill_vacuum_lib/src/lib.rs
@@ -186,7 +186,7 @@ impl HardcodedActions
         }
     }
 
-    /// Whever the action's keys were pressed.
+    /// Whether the action's keys were pressed.
     #[inline]
     #[must_use]
     pub fn pressed(self, key_inputs: &ButtonInput<KeyCode>) -> bool

--- a/hill_vacuum_lib/src/map/brush/convex_polygon.rs
+++ b/hill_vacuum_lib/src/map/brush/convex_polygon.rs
@@ -2747,7 +2747,7 @@ impl ConvexPolygon
     }
 
     /// Adds a vertex to the polygon if it's possible to do so without losing convexity and returns
-    /// whever it was possible to do so.
+    /// whether it was possible to do so.
     #[inline]
     pub(in crate::map::brush) fn try_vertex_insertion_at_index(
         &mut self,

--- a/hill_vacuum_lib/src/map/brush/mod.rs
+++ b/hill_vacuum_lib/src/map/brush/mod.rs
@@ -1710,7 +1710,7 @@ impl Brush
     }
 
     /// Adds a vertex to the polygon if it's possible to do so without losing convexity and returns
-    /// whever it was possible to do so.
+    /// whether it was possible to do so.
     #[inline]
     #[must_use]
     pub fn try_vertex_insertion_at_index(
@@ -1847,7 +1847,7 @@ impl Brush
         self.path_mut().translate(old_center - center);
     }
 
-    /// Returns a [`SplitResult`] describing whever the polygon can be split.
+    /// Returns a [`SplitResult`] describing whether the polygon can be split.
     #[inline]
     pub fn check_split(&self) -> SplitResult { (self.data.polygon.check_split(), self.id).into() }
 
@@ -1915,7 +1915,7 @@ impl Brush
             .map(|(side, normal, info)| (side, normal, XtrusionPayload(self.id, info)))
     }
 
-    /// Returns a [`XtrusionResult`] describing whever the xtrusion attempt can occur.
+    /// Returns a [`XtrusionResult`] describing whether the xtrusion attempt can occur.
     #[inline]
     pub fn matching_xtrusion_info(&self, normal: Vec2) -> XtrusionResult
     {
@@ -2456,7 +2456,7 @@ pub struct BrushViewer
     pub texture:    Option<TextureSettings>,
     /// The [`Mover`].
     pub mover:      Mover,
-    /// Whever collision against the polygonal shape is enabled.
+    /// Whether collision against the polygonal shape is enabled.
     pub collision:  bool,
     /// The properties.
     pub properties: HvHashMap<String, Value>

--- a/hill_vacuum_lib/src/map/drawer/animation/mod.rs
+++ b/hill_vacuum_lib/src/map/drawer/animation/mod.rs
@@ -180,7 +180,7 @@ impl Animation
     #[inline]
     pub const fn atlas_animation() -> Self { Self::Atlas(Atlas::new()) }
 
-    /// Whever there is no animation.
+    /// Whether there is no animation.
     #[inline]
     #[must_use]
     pub const fn is_none(&self) -> bool { matches!(self, Self::None) }
@@ -303,7 +303,7 @@ impl Atlas
     #[must_use]
     pub const fn y_partition(&self) -> u32 { self.y }
 
-    /// Whever the [`Timing`] is uniform.
+    /// Whether the [`Timing`] is uniform.
     #[inline]
     #[must_use]
     pub(in crate::map) const fn is_uniform(&self) -> bool

--- a/hill_vacuum_lib/src/map/drawer/drawing_resources.rs
+++ b/hill_vacuum_lib/src/map/drawer/drawing_resources.rs
@@ -250,7 +250,7 @@ pub(in crate::map) struct DrawingResources
     thing_angle_texture: Handle<ColorMaterial>,
     /// The names of the textures with [`Animations`].
     animated_textures: HvHashSet<String>,
-    /// Whever any default texture animation was changed.
+    /// Whether any default texture animation was changed.
     default_animation_changed: bool
 }
 
@@ -476,7 +476,7 @@ impl DrawingResources
         }
     }
 
-    /// Whever a default animation was changed.
+    /// Whether a default animation was changed.
     #[inline]
     #[must_use]
     pub const fn default_animations_changed(&self) -> bool { self.default_animation_changed }
@@ -1673,7 +1673,7 @@ pub(in crate::map) struct TextureMut<'a>
     resources:     &'a mut DrawingResources,
     /// The name of the texture.
     name:          String,
-    /// Whever the [`Texture`] had no animation when the struct was created.
+    /// Whether the [`Texture`] had no animation when the struct was created.
     was_anim_none: bool
 }
 

--- a/hill_vacuum_lib/src/map/drawer/mod.rs
+++ b/hill_vacuum_lib/src/map/drawer/mod.rs
@@ -97,9 +97,9 @@ pub(in crate::map) struct EditDrawer<'w, 's, 'a>
     camera_scale:           f32,
     /// The time that has passed since startup.
     elapsed_time:           f32,
-    /// Whever the collision overlay of the [`Brush`]es should be shown.
+    /// Whether the collision overlay of the [`Brush`]es should be shown.
     show_collision_overlay: bool,
-    /// Whever parallax is enabled.
+    /// Whether parallax is enabled.
     parallax_enabled:       bool
 }
 

--- a/hill_vacuum_lib/src/map/drawer/texture.rs
+++ b/hill_vacuum_lib/src/map/drawer/texture.rs
@@ -264,7 +264,7 @@ pub trait TextureInterface
     #[must_use]
     fn height_f32(&self) -> f32;
 
-    /// Whever the texture should be rendered like a sprite
+    /// Whether the texture should be rendered like a sprite
     #[must_use]
     fn sprite(&self) -> bool;
 
@@ -298,7 +298,7 @@ pub(in crate::map) trait TextureInterfaceExtra
 //
 //=======================================================================//
 
-/// Whever the texture should be rendered as a sprite.
+/// Whether the texture should be rendered as a sprite.
 #[must_use]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
 pub enum Sprite
@@ -342,7 +342,7 @@ impl From<bool> for Sprite
 
 impl Sprite
 {
-    /// Whever `self` has value `Sprite::True`.
+    /// Whether `self` has value `Sprite::True`.
     #[inline]
     #[must_use]
     pub const fn enabled(&self) -> bool { matches!(self, Self::True { .. }) }
@@ -901,7 +901,7 @@ impl Texture
         &mut self.animation
     }
 
-    /// Whever the texture was edited.
+    /// Whether the texture was edited.
     #[inline(always)]
     #[must_use]
     pub const fn dirty(&self) -> bool { self.dirty }
@@ -1078,14 +1078,14 @@ impl TextureSettings
         self.animation.get_list_animation().frame(index)
     }
 
-    /// Checks whever the move is valid.
+    /// Checks whether the move is valid.
     #[inline]
     pub(in crate::map) fn check_move(&self, delta: Vec2, center: Vec2) -> bool
     {
         !self.sprite.enabled() || !(self.sprite_hull(center) + delta).out_of_bounds()
     }
 
-    /// Checks whever the scale is valid. Returns a [`TextureScale`] describing the outcome if it
+    /// Checks whether the scale is valid. Returns a [`TextureScale`] describing the outcome if it
     /// is.
     #[inline]
     pub(in crate::map) fn check_scale(
@@ -1137,7 +1137,7 @@ impl TextureSettings
         }
     }
 
-    /// Checks whever the scale and flipping of the texture is valid. Returns a [`TextureScale`]
+    /// Checks whether the scale and flipping of the texture is valid. Returns a [`TextureScale`]
     /// describing the outcome if it is.
     #[inline]
     pub(in crate::map) fn check_flip_scale(
@@ -1216,7 +1216,7 @@ impl TextureSettings
         }
     }
 
-    /// Whever the texture change is valid.
+    /// Whether the texture change is valid.
     #[inline]
     pub(in crate::map) fn check_texture_change(
         &mut self,
@@ -1288,7 +1288,7 @@ impl TextureSettings
         std::mem::replace(&mut self.height, value).into()
     }
 
-    /// Whever the new angle is valid.
+    /// Whether the new angle is valid.
     #[inline]
     pub(in crate::map) fn check_angle(
         &mut self,
@@ -1311,7 +1311,7 @@ impl TextureSettings
         result.is_ok()
     }
 
-    /// Checks whever the rotation is valid. If valid returns a [`TextureRotation`] describing the
+    /// Checks whether the rotation is valid. If valid returns a [`TextureRotation`] describing the
     /// outcome, if valid.
     #[inline]
     pub(in crate::map) fn check_rotation(
@@ -1456,7 +1456,7 @@ impl TextureSettings
         (prev, offset_x, offset_y).into()
     }
 
-    /// Checks whever the texture is within bounds.
+    /// Checks whether the texture is within bounds.
     #[inline]
     #[must_use]
     pub(in crate::map) fn check_within_bounds(
@@ -1468,7 +1468,7 @@ impl TextureSettings
         self.check_sprite_vxs(drawing_resources, center).is_ok()
     }
 
-    /// Checks whever changing animation makes the sprite, if any, go out of bounds.
+    /// Checks whether changing animation makes the sprite, if any, go out of bounds.
     #[inline]
     #[must_use]
     pub(in crate::map) fn check_animation_change(
@@ -1708,7 +1708,7 @@ impl TextureSettings
         rect.into()
     }
 
-    /// Checks whever the sprite, if any, fits within the map.
+    /// Checks whether the sprite, if any, fits within the map.
     #[inline]
     pub(in crate::map) fn check_sprite_vxs(
         &self,

--- a/hill_vacuum_lib/src/map/editor/cursor_pos.rs
+++ b/hill_vacuum_lib/src/map/editor/cursor_pos.rs
@@ -32,7 +32,7 @@ pub(in crate::map::editor) struct Cursor
     delta_ui:               Vec2,
     /// The bounding box describing the map grid square the cursor is currently in.
     grid_square:            Hull,
-    /// Whever the cursor is set to be snapped to the grid.
+    /// Whether the cursor is set to be snapped to the grid.
     snap:                   bool,
     /// The position of the cursor on the map in the previous frame.
     previous_world:         Vec2,
@@ -66,7 +66,7 @@ impl Default for Cursor
 
 impl Cursor
 {
-    /// Whever the cursor was moved.
+    /// Whether the cursor was moved.
     #[inline]
     #[must_use]
     pub fn moved(&self) -> bool { self.delta_ui != Vec2::ZERO }
@@ -120,7 +120,7 @@ impl Cursor
     #[must_use]
     pub const fn delta_ui(&self) -> Vec2 { self.delta_ui }
 
-    /// Whever grid snap is enabled.
+    /// Whether grid snap is enabled.
     #[inline]
     #[must_use]
     pub const fn snap(&self) -> bool { self.snap }

--- a/hill_vacuum_lib/src/map/editor/state/clipboard.rs
+++ b/hill_vacuum_lib/src/map/editor/state/clipboard.rs
@@ -181,7 +181,7 @@ impl EntityCenter for ClipboardData
 
 impl ClipboardData
 {
-    /// Whever `self` is out of bounds if moved by the amount `delta`.
+    /// Whether `self` is out of bounds if moved by the amount `delta`.
     #[inline]
     #[must_use]
     fn out_of_bounds(&self, delta: Vec2) -> bool { (self.hull() + delta).out_of_bounds() }
@@ -353,7 +353,7 @@ impl Prop
     //==============================================================
     // Info
 
-    /// Whever `self` contains copied entities.
+    /// Whether `self` contains copied entities.
     #[inline]
     #[must_use]
     fn has_data(&self) -> bool { !self.data.is_empty() }
@@ -486,7 +486,7 @@ impl Prop
             .center();
     }
 
-    /// Updates the things of the contained [`ThingInstance`]s after a things reload. Returns whever
+    /// Updates the things of the contained [`ThingInstance`]s after a things reload. Returns whether
     /// any thing were changed.
     #[inline]
     #[must_use]
@@ -510,7 +510,7 @@ impl Prop
         false
     }
 
-    /// Updates the textures of the contained [`Brush`]es after a texture reload. Returns whever any
+    /// Updates the textures of the contained [`Brush`]es after a texture reload. Returns whether any
     /// textures were changed.
     #[inline]
     #[must_use]
@@ -719,7 +719,7 @@ impl PropScreenshotTimer
     #[must_use]
     pub fn id(&self) -> bevy::prelude::Entity { self.1.unwrap() }
 
-    /// Updates the assigned camera, deactivating it once the time has finished. Returns whever the
+    /// Updates the assigned camera, deactivating it once the time has finished. Returns whether the
     /// camera has been disabled.
     #[inline]
     pub fn update(&mut self, prop_cameras: &mut PropCamerasMut) -> bool
@@ -764,7 +764,7 @@ pub(in crate::map::editor::state) struct Clipboard
     ui_text: String,
     /// The copied platform path, if any.
     platform_path: Option<Path>,
-    /// Whever the stored [`Prop`]s were edited.
+    /// Whether the stored [`Prop`]s were edited.
     props_changed: bool,
     /// The [`Prop`]s which have an assigned camera to take their screenshot.
     props_with_assigned_camera: ArrayVec<(PropScreenshotTimer, usize), PROP_CAMERAS_AMOUNT>,
@@ -916,7 +916,7 @@ impl Clipboard
     //==============================================================
     // Info
 
-    /// Whever `self` was edited.
+    /// Whether `self` was edited.
     #[inline]
     #[must_use]
     pub const fn props_changed(&self) -> bool { self.props_changed }
@@ -936,12 +936,12 @@ impl Clipboard
     #[must_use]
     pub const fn selected_prop_index(&self) -> Option<usize> { self.selected_prop }
 
-    /// Whever the quick prop stored contains entities.
+    /// Whether the quick prop stored contains entities.
     #[inline]
     #[must_use]
     pub fn has_quick_prop(&self) -> bool { self.quick_prop.has_data() }
 
-    /// Whever there are no [`Prop`]s stored.
+    /// Whether there are no [`Prop`]s stored.
     #[inline]
     #[must_use]
     pub fn no_props(&self) -> bool { self.props.is_empty() && !self.has_quick_prop() }

--- a/hill_vacuum_lib/src/map/editor/state/core/item_selector.rs
+++ b/hill_vacuum_lib/src/map/editor/state/core/item_selector.rs
@@ -255,8 +255,12 @@ where
             }
         };
 
-        let value = Some(self.items[self.depth]);
-        self.previous = value;
-        value
+        if let Position::None = self.depth {
+            None
+        } else {
+            let value = Some(self.items[self.depth]);
+            self.previous = value;
+            value
+        }
     }
 }

--- a/hill_vacuum_lib/src/map/editor/state/core/item_selector.rs
+++ b/hill_vacuum_lib/src/map/editor/state/core/item_selector.rs
@@ -95,7 +95,7 @@ impl<T> ItemsBeneathCursor<T>
 where
     T: EntityId + Clone + Copy + PartialEq
 {
-    /// Whever there are no items.
+    /// Whether there are no items.
     #[inline]
     fn is_empty(&self) -> bool { self.selected.is_empty() && self.non_selected.is_empty() }
 

--- a/hill_vacuum_lib/src/map/editor/state/core/map_preview.rs
+++ b/hill_vacuum_lib/src/map/editor/state/core/map_preview.rs
@@ -125,7 +125,7 @@ impl MapPreviewTool
 //
 //=======================================================================//
 
-/// Whever the entity with [`Id`] `identifier` moves.
+/// Whether the entity with [`Id`] `identifier` moves.
 #[inline]
 #[must_use]
 fn is_moving(manager: &EntitiesManager, identifier: Id) -> bool

--- a/hill_vacuum_lib/src/map/editor/state/core/mod.rs
+++ b/hill_vacuum_lib/src/map/editor/state/core/mod.rs
@@ -262,12 +262,12 @@ macro_rules! selected_vertexes {
 
         impl SelectedVertexes
         {
-            /// Whever there are any selected vertexes.
+            /// Whether there are any selected vertexes.
             #[inline]
             #[must_use]
             pub const fn any_selected_vx(&self) -> bool { self.1 != 0 }
 
-            /// Whever the vertexes merge is available.
+            /// Whether the vertexes merge is available.
             #[inline]
             #[must_use]
             pub const fn vx_merge_available(&self) -> bool
@@ -556,7 +556,7 @@ impl<'a> UndoRedoInterface<'a>
         self.manager.remove_texture(identifier)
     }
 
-    /// Sets whever the texture of the selected [`Brush`] with [`Id`] `identifier` should be
+    /// Sets whether the texture of the selected [`Brush`] with [`Id`] `identifier` should be
     /// rendered as a sprite or not. Returns the previous sprite rendering parameters.
     #[inline]
     pub fn set_single_sprite(
@@ -699,7 +699,7 @@ impl Core
     //==============================================================
     // Info
 
-    /// Whever an ongoing multiframe change is happening.
+    /// Whether an ongoing multiframe change is happening.
     #[inline]
     #[must_use]
     pub fn ongoing_multi_frame_change(&self) -> bool
@@ -707,17 +707,17 @@ impl Core
         self.active_tool.ongoing_multi_frame_change()
     }
 
-    /// Whever the entity tool is active.
+    /// Whether the entity tool is active.
     #[inline]
     #[must_use]
     pub const fn entity_tool(&self) -> bool { self.active_tool.entity_tool() }
 
-    /// Whever the active tool has texture editing capabilities.
+    /// Whether the active tool has texture editing capabilities.
     #[inline]
     #[must_use]
     pub const fn texture_tool(&self) -> bool { self.active_tool.texture_tool() }
 
-    /// Whever the map preview is active.
+    /// Whether the map preview is active.
     #[inline]
     #[must_use]
     pub const fn map_preview(&self) -> bool { self.active_tool.map_preview() }
@@ -725,7 +725,7 @@ impl Core
     //==============================================================
     // Save
 
-    /// Whever it is possible to save the file.
+    /// Whether it is possible to save the file.
     #[inline]
     #[must_use]
     pub fn save_available(&self) -> bool { !self.active_tool.ongoing_multi_frame_change() }
@@ -733,7 +733,7 @@ impl Core
     //==============================================================
     // Select all
 
-    /// Whever select all is available.
+    /// Whether select all is available.
     #[inline]
     #[must_use]
     pub fn select_all_available(&self) -> bool { !self.active_tool.ongoing_multi_frame_change() }
@@ -754,7 +754,7 @@ impl Core
     //==============================================================
     // Undo/Redo
 
-    /// Whever undo/redo is available.
+    /// Whether undo/redo is available.
     #[inline]
     #[must_use]
     pub fn undo_redo_available(&self) -> bool { self.active_tool.undo_redo_available() }
@@ -798,7 +798,7 @@ impl Core
     //==============================================================
     // Copy/Paste
 
-    /// Whever it is possible to copy/paste.
+    /// Whether it is possible to copy/paste.
     #[inline]
     #[must_use]
     pub fn copy_paste_available(&self) -> bool { self.active_tool.copy_paste_available() }

--- a/hill_vacuum_lib/src/map/editor/state/core/path_tool/mod.rs
+++ b/hill_vacuum_lib/src/map/editor/state/core/path_tool/mod.rs
@@ -348,7 +348,7 @@ impl PathTool
     //==============================================================
     // Info
 
-    /// Whever copy/paste is available.
+    /// Whether copy/paste is available.
     #[inline]
     #[must_use]
     pub const fn copy_paste_available(&self) -> bool
@@ -356,7 +356,7 @@ impl PathTool
         matches!(self.status, Status::Inactive(..) | Status::AddNodeUi(_) | Status::FreeDrawUi(_))
     }
 
-    /// Whever free draw is active.
+    /// Whether free draw is active.
     #[inline]
     #[must_use]
     pub const fn is_free_draw_active(&self) -> bool
@@ -364,7 +364,7 @@ impl PathTool
         matches!(self.status, Status::SingleEditing(_, PathEditing::FreeDraw(..)))
     }
 
-    /// Whever the movement simulation is active.
+    /// Whether the movement simulation is active.
     #[inline]
     #[must_use]
     pub const fn simulation_active(&self) -> bool { matches!(self.status, Status::Simulation(..)) }
@@ -819,7 +819,7 @@ impl PathTool
         }
     }
 
-    /// Moves the selected [`Node`]s. Returns whever it was possible.
+    /// Moves the selected [`Node`]s. Returns whether it was possible.
     #[inline]
     fn move_nodes(
         manager: &mut EntitiesManager,
@@ -868,7 +868,7 @@ impl PathTool
         true
     }
 
-    /// Updates the editing of a single entity. Returns whever the editing was concluded.
+    /// Updates the editing of a single entity. Returns whether the editing was concluded.
     #[inline]
     #[must_use]
     fn single_editing(
@@ -929,7 +929,7 @@ impl PathTool
         false
     }
 
-    /// Deletes the selected [`Node`]s or [`Path`]s depending on whever alt is pressed.
+    /// Deletes the selected [`Node`]s or [`Path`]s depending on whether alt is pressed.
     #[inline]
     #[must_use]
     fn delete(
@@ -1393,7 +1393,7 @@ impl PathTool
 //
 //=======================================================================//
 
-/// Whever the [`Brush`] with [`Id`] `identifier` is anchored to a selected moving [`Brush`].
+/// Whether the [`Brush`] with [`Id`] `identifier` is anchored to a selected moving [`Brush`].
 #[inline]
 #[must_use]
 fn is_anchored_to_selected_moving(manager: &EntitiesManager, identifier: Id) -> bool
@@ -1407,7 +1407,7 @@ fn is_anchored_to_selected_moving(manager: &EntitiesManager, identifier: Id) -> 
 
 //=======================================================================//
 
-/// Whever the entity with [`Id`] `identifier` moves.
+/// Whether the entity with [`Id`] `identifier` moves.
 #[inline]
 #[must_use]
 fn is_moving(manager: &EntitiesManager, identifier: Id) -> bool

--- a/hill_vacuum_lib/src/map/editor/state/core/path_tool/nodes_editor.rs
+++ b/hill_vacuum_lib/src/map/editor/state/core/path_tool/nodes_editor.rs
@@ -128,7 +128,7 @@ impl NodesEditor
         )
     );
 
-    /// Whever an UI element is being interacted with.
+    /// Whether an UI element is being interacted with.
     #[inline]
     #[must_use]
     pub fn interacting(&self) -> bool { self.interacting.iter().any(|b| *b) }

--- a/hill_vacuum_lib/src/map/editor/state/core/rect.rs
+++ b/hill_vacuum_lib/src/map/editor/state/core/rect.rs
@@ -78,15 +78,15 @@ pub trait RectTrait
     where
         Self: Sized;
 
-    /// Whever `self` represents an uninitiated drag area.
+    /// Whether `self` represents an uninitiated drag area.
     #[must_use]
     fn none(&self) -> bool;
 
-    /// Whever `self` represents an initiated drag area.
+    /// Whether `self` represents an initiated drag area.
     #[must_use]
     fn initiated(&self) -> bool;
 
-    /// Whever `self` represents a formed drag area.
+    /// Whether `self` represents a formed drag area.
     #[must_use]
     fn formed(&self) -> bool;
 
@@ -314,7 +314,7 @@ where
     #[must_use]
     pub const fn highlighted_entity(&self) -> Option<T> { self.1 }
 
-    /// Whever there is an highlighted entity.
+    /// Whether there is an highlighted entity.
     #[inline]
     #[must_use]
     pub const fn has_highlighted_entity(&self) -> bool { self.1.is_some() }
@@ -329,7 +329,7 @@ where
 //
 //=======================================================================//
 
-/// Whever `a` and `b` are valid points to generate a [`Rect`].
+/// Whether `a` and `b` are valid points to generate a [`Rect`].
 #[inline]
 #[must_use]
 fn valid_points(a: Vec2, b: Vec2, camera_scale: f32) -> bool

--- a/hill_vacuum_lib/src/map/editor/state/core/rotate_tool.rs
+++ b/hill_vacuum_lib/src/map/editor/state/core/rotate_tool.rs
@@ -536,7 +536,7 @@ impl RotateTool
         }
     }
 
-    /// Rotates the selected [`Brush`]es. Returns whever it was possible.
+    /// Rotates the selected [`Brush`]es. Returns whether it was possible.
     #[inline]
     fn rotate_brushes(
         bundle: &ToolUpdateBundle,
@@ -584,7 +584,7 @@ impl RotateTool
         true
     }
 
-    /// Rotates the textures of the selected [`Brush`]es. Returns whever it could be done.
+    /// Rotates the textures of the selected [`Brush`]es. Returns whether it could be done.
     #[inline]
     fn rotate_textures(bundle: &ToolUpdateBundle, manager: &mut EntitiesManager, angle: f32)
         -> bool

--- a/hill_vacuum_lib/src/map/editor/state/core/scale_tool.rs
+++ b/hill_vacuum_lib/src/map/editor/state/core/scale_tool.rs
@@ -495,7 +495,7 @@ impl ScaleTool
         new_hull.into()
     }
 
-    /// Checks whever there is an outline vertex near the cursor.
+    /// Checks whether there is an outline vertex near the cursor.
     #[inline]
     fn check_scale_vertex_proximity(
         &mut self,

--- a/hill_vacuum_lib/src/map/editor/state/core/shear_tool.rs
+++ b/hill_vacuum_lib/src/map/editor/state/core/shear_tool.rs
@@ -294,7 +294,7 @@ impl ShearTool
         };
     }
 
-    /// Checks whever there is a side of the outline near `cursor_pos`.
+    /// Checks whether there is a side of the outline near `cursor_pos`.
     #[inline]
     fn check_shear_side_proximity(&mut self, cursor_pos: Vec2, camera_scale: f32)
     {

--- a/hill_vacuum_lib/src/map/editor/state/core/side_tool.rs
+++ b/hill_vacuum_lib/src/map/editor/state/core/side_tool.rs
@@ -226,12 +226,12 @@ impl BrushesWithSelectedSides
         }
     }
 
-    /// Whever the vertex merge is available.
+    /// Whether the vertex merge is available.
     #[inline]
     #[must_use]
     const fn vx_merge_available(&self) -> bool { self.selected_sides.vx_merge_available() }
 
-    /// Whever the xtrusion is available.
+    /// Whether the xtrusion is available.
     #[inline]
     #[must_use]
     fn xtrusion_available(&self) -> bool
@@ -423,7 +423,7 @@ impl SideTool
     //==============================================================
     // Info
 
-    /// Whever an intrusion is currently happening.
+    /// Whether an intrusion is currently happening.
     #[inline]
     #[must_use]
     pub const fn intrusion(&self) -> bool
@@ -439,11 +439,11 @@ impl SideTool
     #[must_use]
     const fn cursor_pos(cursor: &Cursor) -> Vec2 { cursor.world() }
 
-    /// Whever the vertexes merge is available.
+    /// Whether the vertexes merge is available.
     #[inline]
     pub const fn vx_merge_available(&self) -> bool { self.1.vx_merge_available() }
 
-    /// Whever the xtrusion is available.
+    /// Whether the xtrusion is available.
     #[inline]
     #[must_use]
     pub fn xtrusion_available(&self) -> bool { self.1.xtrusion_available() }
@@ -1022,7 +1022,7 @@ impl SideTool
         });
     }
 
-    /// Whever the xtrusion is moving against the side normal.
+    /// Whether the xtrusion is moving against the side normal.
     #[inline]
     fn xtrusion_delta_against_normal(normal: Vec2, delta: Vec2) -> bool { delta.dot(normal) < 0f32 }
 

--- a/hill_vacuum_lib/src/map/editor/state/core/tool.rs
+++ b/hill_vacuum_lib/src/map/editor/state/core/tool.rs
@@ -129,11 +129,11 @@ where
     #[must_use]
     fn tooltip_label(self, binds: &BindsKeyCodes) -> String;
 
-    /// Whever the tool can be enabled.
+    /// Whether the tool can be enabled.
     #[must_use]
     fn change_conditions_met(self, change_conditions: &ChangeConditions) -> bool;
 
-    /// Whever the tool is a subtool.
+    /// Whether the tool is a subtool.
     #[must_use]
     fn subtool(self) -> bool;
 
@@ -144,13 +144,13 @@ where
 
 //=======================================================================//
 
-/// A trait to return whever the tool is enabled.
+/// A trait to return whether the tool is enabled.
 pub(in crate::map::editor::state) trait EnabledTool
 {
     /// The tool to check if it's enabled.
     type Item: ToolInterface;
 
-    /// Whever the tool associated with `tool` is enabled.
+    /// Whether the tool associated with `tool` is enabled.
     #[must_use]
     fn is_tool_enabled(&self, tool: Self::Item) -> bool;
 }
@@ -166,10 +166,10 @@ pub(in crate::map::editor::state) trait DisableSubtool
 
 //=======================================================================//
 
-/// A trait to return whever a tool has any ongoing multiframe changes.
+/// A trait to return whether a tool has any ongoing multiframe changes.
 pub(in crate::map::editor::state) trait OngoingMultiframeChange
 {
-    /// Whever there are any ongoing multiframe changes.
+    /// Whether there are any ongoing multiframe changes.
     #[must_use]
     fn ongoing_multi_frame_change(&self) -> bool;
 }
@@ -289,7 +289,7 @@ impl EditingTarget
         }
     }
 
-    /// Whever the change of [`EditingTarget`] requires certain edits to be purged from the
+    /// Whether the change of [`EditingTarget`] requires certain edits to be purged from the
     /// [`EditsHistory`].
     #[inline]
     #[must_use]
@@ -439,7 +439,7 @@ impl ActiveTool
         .unwrap_or_default()
     }
 
-    /// Whever the simulation of the moving entities is active.
+    /// Whether the simulation of the moving entities is active.
     #[inline]
     #[must_use]
     pub const fn path_simulation_active(&self) -> bool
@@ -447,12 +447,12 @@ impl ActiveTool
         return_if_no_match!(self, Self::Path(t), t, false).simulation_active()
     }
 
-    /// Whever the entity tool is active.
+    /// Whether the entity tool is active.
     #[inline]
     #[must_use]
     pub const fn entity_tool(&self) -> bool { matches!(self, Self::Entity(_)) }
 
-    /// Whever a tool with texture editing capabilities is available.
+    /// Whether a tool with texture editing capabilities is available.
     #[inline]
     #[must_use]
     pub const fn texture_tool(&self) -> bool
@@ -460,7 +460,7 @@ impl ActiveTool
         matches!(self, Self::Entity(_) | Self::Scale(_) | Self::Rotate(_) | Self::Flip(_))
     }
 
-    /// Whever the vertexes merge is available.
+    /// Whether the vertexes merge is available.
     #[inline]
     #[must_use]
     pub const fn vx_merge_available(&self) -> bool
@@ -473,7 +473,7 @@ impl ActiveTool
         }
     }
 
-    /// Whever the split subtoon is available.
+    /// Whether the split subtoon is available.
     #[inline]
     #[must_use]
     pub fn split_available(&self) -> bool
@@ -481,7 +481,7 @@ impl ActiveTool
         return_if_no_match!(self, Self::Vertex(t), t, false).split_available()
     }
 
-    /// Whever the x-trusion subtool is available.
+    /// Whether the x-trusion subtool is available.
     #[inline]
     #[must_use]
     fn xtrusion_available(&self) -> bool
@@ -489,7 +489,7 @@ impl ActiveTool
         return_if_no_match!(self, Self::Side(t), t, false).xtrusion_available()
     }
 
-    /// Whever map preview is active.
+    /// Whether map preview is active.
     #[inline]
     #[must_use]
     pub const fn map_preview(&self) -> bool { matches!(self, Self::MapPreview { .. }) }
@@ -497,7 +497,7 @@ impl ActiveTool
     //==============================================================
     // Copy/Paste
 
-    /// Whever copy/paste is available.
+    /// Whether copy/paste is available.
     #[inline]
     #[must_use]
     pub fn copy_paste_available(&self) -> bool
@@ -677,7 +677,7 @@ impl ActiveTool
     //==============================================================
     // Undo/Redo
 
-    /// Whever it is possible to select all the entities.
+    /// Whether it is possible to select all the entities.
     #[inline]
     #[must_use]
     pub fn select_all_available(&self) -> bool { !self.ongoing_multi_frame_change() }
@@ -725,7 +725,7 @@ impl ActiveTool
     //==============================================================
     // Undo/Redo
 
-    /// Whever undo/redo is avauilable.
+    /// Whether undo/redo is avauilable.
     #[inline]
     #[must_use]
     pub fn undo_redo_available(&self) -> bool { !self.ongoing_multi_frame_change() }
@@ -1608,7 +1608,7 @@ pub(in crate::map::editor::state) enum Tool
 
 impl Tool
 {
-    /// Whever the bind associated with the tool was pressed.
+    /// Whether the bind associated with the tool was pressed.
     #[inline]
     #[must_use]
     pub fn just_pressed(self, key_inputs: &ButtonInput<KeyCode>, binds: &BindsKeyCodes) -> bool

--- a/hill_vacuum_lib/src/map/editor/state/core/vertex_tool.rs
+++ b/hill_vacuum_lib/src/map/editor/state/core/vertex_tool.rs
@@ -156,12 +156,12 @@ impl BrushesWithSelectedVertexes
         }
     }
 
-    /// Whever the merge subtool is available.
+    /// Whether the merge subtool is available.
     #[inline]
     #[must_use]
     const fn vx_merge_available(&self) -> bool { self.selected_vxs.vx_merge_available() }
 
-    /// Whever the split is available.
+    /// Whether the split is available.
     #[inline]
     #[must_use]
     fn split_available(&self) -> bool
@@ -350,7 +350,7 @@ impl VertexTool
     //==============================================================
     // Info
 
-    /// Whever free draw is active.
+    /// Whether free draw is active.
     #[inline]
     #[must_use]
     pub const fn is_free_draw_active(&self) -> bool { matches!(self.0, Status::PolygonToPath(_)) }
@@ -360,11 +360,11 @@ impl VertexTool
     #[must_use]
     const fn cursor_pos(cursor: &Cursor) -> Vec2 { cursor.world() }
 
-    /// Whever the merge subtool is available.
+    /// Whether the merge subtool is available.
     #[inline]
     pub const fn vx_merge_available(&self) -> bool { self.1.vx_merge_available() }
 
-    /// Whever the split subtool is available.
+    /// Whether the split subtool is available.
     #[inline]
     pub fn split_available(&self) -> bool { self.1.split_available() }
 

--- a/hill_vacuum_lib/src/map/editor/state/editor_state.rs
+++ b/hill_vacuum_lib/src/map/editor/state/editor_state.rs
@@ -86,10 +86,10 @@ const PROPS_EXTENSION: &str = "prps";
 //
 //=======================================================================//
 
-/// A macro to create functions that return whever a key was pressed.
+/// A macro to create functions that return whether a key was pressed.
 macro_rules! pressed {
     ($($key:ident),+) => ( paste::paste! {$(
-        /// Whever the key was pressed.
+        /// Whether the key was pressed.
         #[inline]
         pub const fn [< $key _pressed >](&self) -> bool
         {
@@ -174,7 +174,7 @@ pub(in crate::map::editor::state) use edit_target;
 //
 //=======================================================================//
 
-/// Determines whever the editor should edit entities, or the associaed textures, or both.
+/// Determines whether the editor should edit entities, or the associaed textures, or both.
 #[derive(Clone, Copy, Default, EnumIter, EnumSize, EnumFromUsize, PartialEq, Eq)]
 pub(in crate::map::editor::state) enum TargetSwitch
 {
@@ -211,7 +211,7 @@ impl TargetSwitch
         }
     }
 
-    /// Whever the value of `self` can be changed based on the number of entities and
+    /// Whether the value of `self` can be changed based on the number of entities and
     /// textures in the map.
     #[inline]
     #[must_use]
@@ -258,11 +258,11 @@ impl TargetSwitch
         true
     }
 
-    /// Whever `self` allows editing of entities.
+    /// Whether `self` allows editing of entities.
     #[inline]
     pub const fn entity_editing(self) -> bool { matches!(self, Self::Entity | Self::Both) }
 
-    /// Whever `self` allows editing of textures.
+    /// Whether `self` allows editing of textures.
     #[inline]
     pub const fn texture_editing(self) -> bool { matches!(self, Self::Texture | Self::Both) }
 
@@ -441,22 +441,22 @@ input_presses!(
 
 impl InputsPresses
 {
-    /// Whever shift is pressed.
+    /// Whether shift is pressed.
     #[inline]
     #[must_use]
     pub const fn shift_pressed(&self) -> bool { self.l_shift.pressed() || self.r_shift.pressed() }
 
-    /// Whever alt is pressed.
+    /// Whether alt is pressed.
     #[inline]
     #[must_use]
     pub const fn alt_pressed(&self) -> bool { self.l_alt.pressed() || self.r_alt.pressed() }
 
-    /// Whever ctrl is pressed.
+    /// Whether ctrl is pressed.
     #[inline]
     #[must_use]
     pub const fn ctrl_pressed(&self) -> bool { self.l_ctrl.pressed() || self.r_ctrl.pressed() }
 
-    /// Whever the copy key combo was just pressed.
+    /// Whether the copy key combo was just pressed.
     #[inline]
     #[must_use]
     pub const fn copy_just_pressed(&self) -> bool
@@ -464,7 +464,7 @@ impl InputsPresses
         self.ctrl_pressed() && self.copy.just_pressed()
     }
 
-    /// Whever the paste key combo was just pressed.
+    /// Whether the paste key combo was just pressed.
     #[inline]
     #[must_use]
     pub const fn paste_just_pressed(&self) -> bool
@@ -472,7 +472,7 @@ impl InputsPresses
         self.ctrl_pressed() && self.paste.just_pressed()
     }
 
-    /// Whever the cut key combo was just pressed.
+    /// Whether the cut key combo was just pressed.
     #[inline]
     #[must_use]
     pub const fn cut_just_pressed(&self) -> bool { self.ctrl_pressed() && self.cut.just_pressed() }
@@ -517,7 +517,7 @@ pub(in crate::map) struct ToolsSettings
 {
     /// The current editing target (entities, textures, or both).
     target_switch: TargetSwitch,
-    /// Whever the [`TargetSwitch`] can be changed in value.
+    /// Whether the [`TargetSwitch`] can be changed in value.
     can_switch: bool,
     /// The resolution of the circle drawing tool (how many sides the circle has).
     pub(in crate::map::editor::state) circle_draw_resolution: u8,
@@ -526,9 +526,9 @@ pub(in crate::map) struct ToolsSettings
     pub(in crate::map::editor::state) texture_scale_interval: f32,
     /// The minimum angle the entities can be rotated when using the rotate tool.
     pub(in crate::map::editor::state) rotate_angle: RotateAngle,
-    /// Whever texture scrolling is enabled while editing the map.
+    /// Whether texture scrolling is enabled while editing the map.
     pub scroll_enabled: bool,
-    /// Whever texture parallax is enabled while editing the map.
+    /// Whether texture parallax is enabled while editing the map.
     pub parallax_enabled: bool,
     /// The spawn pivot of the [`ThingInstance`] used by the thing tool.
     pub(in crate::map::editor::state) thing_pivot: ThingPivot
@@ -595,7 +595,7 @@ impl ToolsSettings
         self.target_switch
     }
 
-    /// Whever entities editing is enabled.
+    /// Whether entities editing is enabled.
     #[inline]
     #[must_use]
     pub(in crate::map::editor::state) const fn entity_editing(&self) -> bool
@@ -603,7 +603,7 @@ impl ToolsSettings
         self.target_switch.entity_editing()
     }
 
-    /// Whever texture editing is enabled.
+    /// Whether texture editing is enabled.
     #[inline]
     #[must_use]
     pub(in crate::map::editor::state) const fn texture_editing(&self) -> bool
@@ -650,18 +650,18 @@ pub(in crate::map::editor) struct State
     tools_settings:     ToolsSettings,
     /// The UI of the editor.
     ui:                 Ui,
-    /// Whever tooltips should be shown (ex. coordinates of the vertexes).
+    /// Whether tooltips should be shown (ex. coordinates of the vertexes).
     show_tooltips:      bool,
-    /// Whever the cursor shuld be snapped to the grid.
+    /// Whether the cursor shuld be snapped to the grid.
     cursor_snap:        bool,
-    /// Whever a grey semitransparent rectangle should be drawn on the map beneath the cursor.
+    /// Whether a grey semitransparent rectangle should be drawn on the map beneath the cursor.
     show_cursor:        bool,
-    /// Whever the "clip" texture should be drawn on top of the [`Brush`]es with collision enabled.
+    /// Whether the "clip" texture should be drawn on top of the [`Brush`]es with collision enabled.
     show_collision:     bool,
-    /// Whever textures are currently being reloaded.
+    /// Whether textures are currently being reloaded.
     reloading_textures: bool,
     #[cfg(feature = "debug")]
-    /// Whever debug lines should be drawn on top of the map.
+    /// Whether debug lines should be drawn on top of the map.
     show_debug_lines:   bool
 }
 
@@ -697,7 +697,7 @@ impl State
 
     pressed!(ctrl, shift);
 
-    /// Whever space is pressed.
+    /// Whether space is pressed.
     #[inline]
     pub const fn space_pressed(&self) -> bool { self.inputs.space.pressed() }
 
@@ -831,7 +831,7 @@ impl State
     #[must_use]
     pub fn grid_size_f32(&self) -> f32 { f32::from(self.grid.size()) }
 
-    /// Whever the cursor shuld be snapped to the grid.
+    /// Whether the cursor shuld be snapped to the grid.
     #[inline]
     #[must_use]
     pub const fn cursor_snap(&self) -> bool { self.cursor_snap }
@@ -845,17 +845,17 @@ impl State
     #[must_use]
     pub const fn tools_settings(&self) -> &ToolsSettings { &self.tools_settings }
 
-    /// Whever map preview mode is enabled.
+    /// Whether map preview mode is enabled.
     #[inline]
     #[must_use]
     pub const fn map_preview(&self) -> bool { self.core.map_preview() }
 
-    /// Whever the [`Brush`]es collision overlay should be drawn.
+    /// Whether the [`Brush`]es collision overlay should be drawn.
     #[inline]
     #[must_use]
     pub const fn show_collision_overlay(&self) -> bool { self.show_collision }
 
-    /// Checks whever any hardcoded keyboard input was pressed and executes the necessary piece of
+    /// Checks whether any hardcoded keyboard input was pressed and executes the necessary piece of
     /// code. Returns true if that was the case.
     #[inline]
     #[must_use]
@@ -1067,7 +1067,7 @@ impl State
     //==============================================================
     // Save
 
-    /// Whever there are no unsaved changes.
+    /// Whether there are no unsaved changes.
     #[inline]
     #[must_use]
     const fn no_edits(&self, drawing_resources: &DrawingResources) -> bool
@@ -1089,7 +1089,7 @@ impl State
         save_as: Option<&'static str>
     ) -> Result<(), &'static str>
     {
-        /// Tests whever `test` is an error and returns an [`Err`] wrapping the error message `err`.
+        /// Tests whether `test` is an error and returns an [`Err`] wrapping the error message `err`.
         macro_rules! test {
             ($test:expr, $err:literal) => {
                 if $test.is_err()
@@ -1112,7 +1112,7 @@ impl State
 
         impl SaveTarget
         {
-            /// Whever `self` represents a new file to create.
+            /// Whether `self` represents a new file to create.
             #[inline]
             #[must_use]
             const fn is_new(&self) -> bool { matches!(self, Self::New(_)) }
@@ -1419,7 +1419,7 @@ impl State
     //==============================================================
     // Copy/Paste
 
-    /// Whever copy paste is available.
+    /// Whether copy paste is available.
     #[inline]
     #[must_use]
     fn copy_paste_available(&self) -> bool { self.core.copy_paste_available() }

--- a/hill_vacuum_lib/src/map/editor/state/edits_history/edit.rs
+++ b/hill_vacuum_lib/src/map/editor/state/edits_history/edit.rs
@@ -44,28 +44,28 @@ impl Edit
     #[must_use]
     pub fn len(&self) -> usize { self.0.len() }
 
-    /// Whever `self` contains no sub-edits.
+    /// Whether `self` contains no sub-edits.
     #[inline]
     #[must_use]
     pub fn is_empty(&self) -> bool { self.len() == 0 }
 
-    /// Whever `self` contains a sub-edits that is only useful as long as the current tool remains
+    /// Whether `self` contains a sub-edits that is only useful as long as the current tool remains
     /// unchanged.
     #[inline]
     #[must_use]
     pub fn contains_tool_edit(&self) -> bool { self.0.iter().any(|(_, et)| et.tool_edit()) }
 
-    /// Whever `self` contains a texture sub-edit.
+    /// Whether `self` contains a texture sub-edit.
     #[inline]
     #[must_use]
     pub fn contains_texture_edit(&self) -> bool { self.0.iter().any(|(_, et)| et.texture_edit()) }
 
-    /// Whever `self` contains a thing edit.
+    /// Whether `self` contains a thing edit.
     #[inline]
     #[must_use]
     pub fn contains_thing_edit(&self) -> bool { self.0.iter().any(|(_, et)| et.thing_edit()) }
 
-    /// Whever `self` contains a free draw sub-edit.
+    /// Whether `self` contains a free draw sub-edit.
     #[inline]
     #[must_use]
     pub fn contains_free_draw_edit(&self) -> bool
@@ -75,7 +75,7 @@ impl Edit
         })
     }
 
-    /// Whever `self` only contains entity selection sub-edits.
+    /// Whether `self` only contains entity selection sub-edits.
     #[inline]
     #[must_use]
     pub fn only_contains_entity_selection_edits(&self) -> bool
@@ -90,7 +90,7 @@ impl Edit
             .all(|(_, et)| matches!(et, EditType::EntitySelection | EditType::EntityDeselection))
     }
 
-    /// Whever `self` only contains selection sub-edits.
+    /// Whether `self` only contains selection sub-edits.
     #[inline]
     #[must_use]
     pub fn only_contains_selection_edits(&self) -> bool

--- a/hill_vacuum_lib/src/map/editor/state/edits_history/edit_type.rs
+++ b/hill_vacuum_lib/src/map/editor/state/edits_history/edit_type.rs
@@ -83,12 +83,12 @@ impl BrushType
         }
     }
 
-    /// Whever `self` is `BrushType::Selected`.
+    /// Whether `self` is `BrushType::Selected`.
     #[inline]
     #[must_use]
     pub const fn selected(self) -> bool { !matches!(self, Self::NotSelected) }
 
-    /// Whever `self` is `BrushType::Drawn`.
+    /// Whether `self` is `BrushType::Drawn`.
     #[inline]
     #[must_use]
     pub const fn drawn(self) -> bool { matches!(self, Self::Drawn) }
@@ -278,7 +278,7 @@ pub(in crate::map::editor::state::edits_history) enum EditType
 
 impl EditType
 {
-    /// Whever `self` is an edit that is only useful as long as the current tool remains unchanged.
+    /// Whether `self` is an edit that is only useful as long as the current tool remains unchanged.
     #[inline]
     #[must_use]
     pub const fn tool_edit(&self) -> bool
@@ -298,7 +298,7 @@ impl EditType
         )
     }
 
-    /// Whever `self` is a texture edit.
+    /// Whether `self` is a texture edit.
     #[inline]
     #[must_use]
     pub const fn texture_edit(&self) -> bool
@@ -339,7 +339,7 @@ impl EditType
         )
     }
 
-    /// Whever `self` represents a [`ThingInstance`] edit.
+    /// Whether `self` represents a [`ThingInstance`] edit.
     #[inline]
     #[must_use]
     pub const fn thing_edit(&self) -> bool
@@ -387,7 +387,7 @@ impl EditType
     }
 
     /// Actions common to both the undo and redo procedures that apply to multiple [`Brush`]es.
-    /// Returns whever the edit was undone/redone.
+    /// Returns whether the edit was undone/redone.
     #[inline]
     #[must_use]
     fn brushes_common(
@@ -490,7 +490,7 @@ impl EditType
     }
 
     /// Actions common to both the undo and redo procedures that apply to a single [`Brush`].
-    /// Returns whever the edit was undone/redone.
+    /// Returns whether the edit was undone/redone.
     #[inline]
     #[must_use]
     fn brush_common(
@@ -580,7 +580,7 @@ impl EditType
     }
 
     /// Actions common to both the undo and redo procedures that apply to a single [`Thing`].
-    /// Returns whever the edit was undone/redone.
+    /// Returns whether the edit was undone/redone.
     #[inline]
     #[must_use]
     fn thing_common(&mut self, interface: &mut UndoRedoInterface, identifier: Id) -> bool
@@ -605,7 +605,7 @@ impl EditType
     }
 
     /// Actions common to both the undo and redo procedures that apply to a default animation.
-    /// Returns whever the edit was undone/redone.
+    /// Returns whether the edit was undone/redone.
     #[inline]
     #[must_use]
     fn default_animation_common(&mut self, animation: &mut Animation) -> bool
@@ -690,7 +690,7 @@ impl EditType
     }
 
     /// Action common to both the undo and redo procedures concerning a property edit.
-    /// Returns whever the edit was undone/redone.
+    /// Returns whether the edit was undone/redone.
     #[inline]
     #[must_use]
     fn property(

--- a/hill_vacuum_lib/src/map/editor/state/edits_history/mod.rs
+++ b/hill_vacuum_lib/src/map/editor/state/edits_history/mod.rs
@@ -181,7 +181,7 @@ pub(in crate::map::editor::state) struct EditsHistory
     /// The edit of the current frame, to be pushed onto the stack at the end of the current frame
     /// if it's not empty.
     current_edit: Edit,
-    /// Whever an edit lasting more than a frame is happening.
+    /// Whether an edit lasting more than a frame is happening.
     multiframe_edit: bool,
     /// The amount of states we can undo.
     prev_states_amount: usize,
@@ -191,7 +191,7 @@ pub(in crate::map::editor::state) struct EditsHistory
     earliest_texture_edit: Option<usize>,
     /// The index of the earliest [`ThingInstance`] edit.
     earliest_thing_edit: Option<usize>,
-    /// Whever the push of the new [`Edit`] was halted to avoid the truncation of the history
+    /// Whether the push of the new [`Edit`] was halted to avoid the truncation of the history
     /// because it only contains selection edits
     selections_only_edit_halted: bool,
     /// The index of the edit where the file was saved the last time, if any.
@@ -721,7 +721,7 @@ impl EditsHistory
         }
     }
 
-    /// Whever there is an ongoing multiframe edit.
+    /// Whether there is an ongoing multiframe edit.
     #[inline]
     #[must_use]
     pub const fn multiframe_edit(&self) -> bool { self.multiframe_edit }
@@ -742,7 +742,7 @@ impl EditsHistory
         self.multiframe_edit = false;
     }
 
-    /// Whever there are no unsaved edits.
+    /// Whether there are no unsaved edits.
     #[inline]
     #[must_use]
     pub const fn no_unsaved_edits(&self) -> bool
@@ -761,7 +761,7 @@ impl EditsHistory
     //=======================================================================//
     // Info
 
-    /// Whever there is no ongoing edit.
+    /// Whether there is no ongoing edit.
     #[inline]
     #[must_use]
     const fn concluded_edit(&self) -> bool { !self.multiframe_edit }

--- a/hill_vacuum_lib/src/map/editor/state/grid.rs
+++ b/hill_vacuum_lib/src/map/editor/state/grid.rs
@@ -22,7 +22,7 @@ pub(in crate::map) struct Grid
 {
     /// The size of the grid's squares.
     size:        i16,
-    /// Whever the grid should be drawn on screen..
+    /// Whether the grid should be drawn on screen..
     pub visible: bool,
     /// When true, the position of the grid squares is shifted by half of its size, both
     /// horizontally and vertically.
@@ -165,7 +165,7 @@ impl Grid
         }
     }
 
-    /// Toggles whever the grid is shifted or not.
+    /// Toggles whether the grid is shifted or not.
     #[inline]
     pub(in crate::map::editor::state) fn toggle_shift(&mut self, manager: &mut EntitiesManager)
     {

--- a/hill_vacuum_lib/src/map/editor/state/input_press.rs
+++ b/hill_vacuum_lib/src/map/editor/state/input_press.rs
@@ -55,7 +55,7 @@ where
         }
     }
 
-    /// Whever the button is currently pressed.
+    /// Whether the button is currently pressed.
     #[inline]
     #[must_use]
     pub const fn pressed(&self) -> bool
@@ -63,7 +63,7 @@ where
         matches!(self.state, State::JustPressed | State::Pressed)
     }
 
-    /// Whever the button has just been pressed.
+    /// Whether the button has just been pressed.
     #[inline]
     #[must_use]
     pub const fn just_pressed(&self) -> bool { matches!(self.state, State::JustPressed) }
@@ -115,7 +115,7 @@ impl InputState
         }
     }
 
-    /// Whever the button has just been pressed.
+    /// Whether the button has just been pressed.
     #[inline]
     #[must_use]
     pub const fn just_pressed(&self) -> bool { matches!(self.state, State::JustPressed) }

--- a/hill_vacuum_lib/src/map/editor/state/manager/mod.rs
+++ b/hill_vacuum_lib/src/map/editor/state/manager/mod.rs
@@ -190,7 +190,7 @@ impl AuxiliaryIds
     #[inline]
     fn new() -> Self { Self(hv_hash_set![capacity; 10]) }
 
-    /// Whever `self` contains `id`.
+    /// Whether `self` contains `id`.
     #[inline]
     #[must_use]
     fn contains(&self, id: Id) -> bool { self.0.contains(&id) }
@@ -268,7 +268,7 @@ impl ErrorHighlight
         self.blinks = Self::ERROR_BLINKS;
     }
 
-    /// Check whever the stored error concerns the entity `error` and removes it if that is the
+    /// Check whether the stored error concerns the entity `error` and removes it if that is the
     /// case.
     #[inline]
     fn check_entity_error_removal(&mut self, error: Id)
@@ -412,24 +412,24 @@ struct Innards
     id_generator: IdGenerator,
     /// The error drawer.
     error_highlight: ErrorHighlight,
-    /// Whever the tool outline should be updated.
+    /// Whether the tool outline should be updated.
     outline_update: bool,
     /// The [`Id`]s of the [`Brush`]es whose amount of selected vertexes changed, necessary for the
     /// update of the vertex and side tools.
     selected_vertexes_update: Ids,
-    /// Whever the texture displayed in the texture editor should be updated.
+    /// Whether the texture displayed in the texture editor should be updated.
     overall_texture_update: bool,
-    /// Whever the info displayed in the platform tool's node editor should be updated.
+    /// Whether the info displayed in the platform tool's node editor should be updated.
     overall_node_update: bool,
-    /// Whever the overall value of the selected [`Brush`]es' collision should be updated.
+    /// Whether the overall value of the selected [`Brush`]es' collision should be updated.
     overall_collision_update: bool,
-    /// Whever the overall properties of the [`Brush`]es should be updated.
+    /// Whether the overall properties of the [`Brush`]es should be updated.
     overall_brushes_properties_update: PropertyUpdate,
-    /// Whever the overall value of the draw height of the selected [`Thing`]s should be updated.
+    /// Whether the overall value of the draw height of the selected [`Thing`]s should be updated.
     overall_things_info_update: bool,
-    /// Whever the overall properties of the [`ThingInstance`]s should be updated.
+    /// Whether the overall properties of the [`ThingInstance`]s should be updated.
     overall_things_properties_update: PropertyUpdate,
-    /// Whever the properties where refactored after loading a map file.
+    /// Whether the properties where refactored after loading a map file.
     refactored_properties: bool
 }
 
@@ -664,7 +664,7 @@ impl Innards
     //==============================================================
     // General
 
-    /// Whever `identifier` is a selected entity.
+    /// Whether `identifier` is a selected entity.
     #[inline]
     #[must_use]
     fn is_selected(&self, identifier: Id) -> bool
@@ -672,7 +672,7 @@ impl Innards
         self.selected_brushes.contains(&identifier) || self.selected_things.contains(&identifier)
     }
 
-    /// Whever `identifier` belongs to an entity that exists.
+    /// Whether `identifier` belongs to an entity that exists.
     #[inline]
     #[must_use]
     fn entity_exists(&self, identifier: Id) -> bool
@@ -1441,7 +1441,7 @@ impl Innards
     }
 
     /// Inserts in the quad trees the [`Hull`] of the anchors of the [`Brush`] with [`Id`], and
-    /// returns whever the procedure was successful. `identifier`.
+    /// returns whether the procedure was successful. `identifier`.
     #[inline]
     #[must_use]
     fn insert_anchors_hull(&mut self, quad_trees: &mut Trees, owner_id: Id) -> bool
@@ -1453,7 +1453,7 @@ impl Innards
     }
 
     /// Removes from the quad trees the [`Hull`] of the anchors of the [`Brush`] with [`Id`]
-    /// `identifier`, and returns whever the procedure was successful.
+    /// `identifier`, and returns whether the procedure was successful.
     #[inline]
     #[must_use]
     fn remove_anchors_hull(&mut self, quad_trees: &mut Trees, owner_id: Id) -> bool
@@ -1466,7 +1466,7 @@ impl Innards
     //==============================================================
     // Things
 
-    /// Whever `identifier` belongs to a [`ThingInstance`].
+    /// Whether `identifier` belongs to a [`ThingInstance`].
     #[inline]
     #[must_use]
     pub fn is_thing(&self, identifier: Id) -> bool { self.things.contains_key(&identifier) }
@@ -1678,7 +1678,7 @@ impl EntitiesManager
     //==============================================================
     // General
 
-    /// Whever the entities properties have been refactored on file load.
+    /// Whether the entities properties have been refactored on file load.
     #[inline(always)]
     #[must_use]
     pub const fn refactored_properties(&self) -> bool { self.innards.refactored_properties }
@@ -1687,7 +1687,7 @@ impl EntitiesManager
     #[inline]
     pub fn reset_refactored_properties(&mut self) { self.innards.refactored_properties = false; }
 
-    /// Whever an entity with [`Id`] `identifier` exists.
+    /// Whether an entity with [`Id`] `identifier` exists.
     #[inline]
     #[must_use]
     pub fn entity_exists(&self, identifier: Id) -> bool
@@ -1814,7 +1814,7 @@ impl EntitiesManager
     //==============================================================
     // Selection
 
-    /// Whever there are any currently selected entities.
+    /// Whether there are any currently selected entities.
     #[inline]
     #[must_use]
     pub fn any_selected_entities(&self) -> bool
@@ -1831,7 +1831,7 @@ impl EntitiesManager
             .map(|id| self.entity(*id))
     }
 
-    /// Whever the entity with [`Id`] `identifier` is selected.
+    /// Whether the entity with [`Id`] `identifier` is selected.
     #[inline]
     #[must_use]
     pub fn is_selected(&self, identifier: Id) -> bool { self.innards.is_selected(identifier) }
@@ -1946,7 +1946,7 @@ impl EntitiesManager
     #[must_use]
     pub fn selected_brushes_amount(&self) -> usize { self.innards.selected_brushes_amount() }
 
-    /// Whever there are any currently selected [`Brush`]es.
+    /// Whether there are any currently selected [`Brush`]es.
     #[inline]
     #[must_use]
     pub fn any_selected_brushes(&self) -> bool { self.selected_brushes_amount() != 0 }
@@ -2854,7 +2854,7 @@ impl EntitiesManager
         self.innards.selected_textured.clear();
     }
 
-    /// Sets whever the texture of the selected [`Brush`]es should be rendered as a sprite or not.
+    /// Sets whether the texture of the selected [`Brush`]es should be rendered as a sprite or not.
     #[inline]
     pub fn set_sprite(
         &mut self,
@@ -2905,7 +2905,7 @@ impl EntitiesManager
         set!(remove_selected_sprite);
     }
 
-    /// Sets whever the texture of the selected [`Brush`] with [`Id`] `identifier` should be
+    /// Sets whether the texture of the selected [`Brush`] with [`Id`] `identifier` should be
     /// rendered as a sprite or not. Returns the previous sprite rendering parameters.
     #[inline]
     pub fn set_single_sprite(
@@ -2962,7 +2962,7 @@ impl EntitiesManager
     //==============================================================
     // Things
 
-    /// Whever `identifier` belongs to a [`ThingInstance`].
+    /// Whether `identifier` belongs to a [`ThingInstance`].
     #[inline]
     #[must_use]
     pub fn is_thing(&self, identifier: Id) -> bool { self.innards.is_thing(identifier) }
@@ -2991,7 +2991,7 @@ impl EntitiesManager
     #[inline]
     pub fn selected_things_amount(&self) -> usize { self.innards.selected_things_amount() }
 
-    /// Whever any [`ThingInstance`] is currently selected.
+    /// Whether any [`ThingInstance`] is currently selected.
     #[inline]
     #[must_use]
     pub fn any_selected_things(&self) -> bool { self.selected_things_amount() != 0 }
@@ -3133,12 +3133,12 @@ impl EntitiesManager
     //==============================================================
     // Moving
 
-    /// Whever the [`Brush`] with [`Id`] `identifier` is moving.
+    /// Whether the [`Brush`] with [`Id`] `identifier` is moving.
     #[inline]
     #[must_use]
     pub fn is_moving(&self, identifier: Id) -> bool { self.innards.moving.contains(&identifier) }
 
-    /// Whever the [`Brush`] with [`Id`] `identifier` is moving and selected.
+    /// Whether the [`Brush`] with [`Id`] `identifier` is moving and selected.
     #[inline]
     #[must_use]
     pub fn is_selected_moving(&self, identifier: Id) -> bool
@@ -3146,7 +3146,7 @@ impl EntitiesManager
         self.innards.selected_moving.contains(&identifier)
     }
 
-    /// Whever there are any entities that don't have a [`Path`] but could have one.
+    /// Whether there are any entities that don't have a [`Path`] but could have one.
     #[inline]
     #[must_use]
     pub fn any_selected_possible_moving(&self) -> bool

--- a/hill_vacuum_lib/src/map/editor/state/manager/quad_tree/mod.rs
+++ b/hill_vacuum_lib/src/map/editor/state/manager/quad_tree/mod.rs
@@ -345,7 +345,7 @@ impl QuadTreeIds
     #[inline]
     fn hulls(&self) -> impl Iterator<Item = &Hull> { self.0.values() }
 
-    /// Whever it contains a value for the specified key.
+    /// Whether it contains a value for the specified key.
     #[inline]
     #[must_use]
     pub fn contains(&self, identifier: Id) -> bool { self.0.contains_key(&identifier) }

--- a/hill_vacuum_lib/src/map/editor/state/manager/quad_tree/node.rs
+++ b/hill_vacuum_lib/src/map/editor/state/manager/quad_tree/node.rs
@@ -105,7 +105,7 @@ impl Square
         )
     }
 
-    /// Whever `self` contains `point` in its area.
+    /// Whether `self` contains `point` in its area.
     #[inline]
     #[must_use]
     fn contains_point(&self, point: Vec2) -> bool
@@ -129,13 +129,13 @@ impl Square
         }
     }
 
-    /// Whever the area covered by `self` intersects `hull`.
+    /// Whether the area covered by `self` intersects `hull`.
     #[inline]
     #[must_use]
     fn overlaps_hull(&self, hull: &Hull) -> bool { hull.overlaps(&self.hull()) }
 
     #[cfg(feature = "debug")]
-    /// Whever the area of `self` is visible within `viewport`.
+    /// Whether the area of `self` is visible within `viewport`.
     #[inline]
     #[must_use]
     fn outline_visible(&self, viewport: &Hull) -> bool { self.hull().intersects(viewport) }
@@ -206,7 +206,7 @@ impl Node
     #[must_use]
     pub fn split_segments(&self) -> SplitSegments { self.square.split_segments() }
 
-    /// Whever `pos` is contained in the covered area.
+    /// Whether `pos` is contained in the covered area.
     #[inline]
     #[must_use]
     pub fn contains_point(&self, pos: Vec2) -> bool { self.square.contains_point(pos) }
@@ -246,7 +246,7 @@ impl Node
     }
 
     /// Stores the ids of the entities of the [`Node`]s that contain `pos` in `identifiers`.
-    /// Returns whever `pos` is contained in the area covered by `self`.
+    /// Returns whether `pos` is contained in the area covered by `self`.
     #[inline]
     pub fn entities_at_pos(
         quad_tree: &QuadTree,

--- a/hill_vacuum_lib/src/map/editor/state/manager/quad_tree/points.rs
+++ b/hill_vacuum_lib/src/map/editor/state/manager/quad_tree/points.rs
@@ -308,7 +308,7 @@ impl Vertexes
     #[must_use]
     pub const fn len(&self) -> usize { self.0.len() }
 
-    /// Returns whever `self` contains no [`Vertex`]es.
+    /// Returns whether `self` contains no [`Vertex`]es.
     #[inline]
     #[must_use]
     pub const fn is_empty(&self) -> bool { self.0.is_empty() }
@@ -401,7 +401,7 @@ impl Intersection
         self.corners.iter().map(|(id, corner)| (id, corner.hull()))
     }
 
-    /// Whever `self` contains a [`Corner`] with [`Id`] `identifier`.
+    /// Whether `self` contains a [`Corner`] with [`Id`] `identifier`.
     #[inline]
     #[must_use]
     pub fn contains_id(&self, identifier: Id) -> bool { self.corners.contains_key(&identifier) }
@@ -476,7 +476,7 @@ impl Intersections
     #[inline]
     pub fn iter(&self) -> impl Iterator<Item = &Intersection> { self.0.iter() }
 
-    /// Whever `self` contains an [`Intersection`] containing `identifier`.
+    /// Whether `self` contains an [`Intersection`] containing `identifier`.
     #[inline]
     #[must_use]
     pub fn contains_id(&self, identifier: Id) -> bool

--- a/hill_vacuum_lib/src/map/editor/state/ui/checkbox.rs
+++ b/hill_vacuum_lib/src/map/editor/state/ui/checkbox.rs
@@ -14,12 +14,12 @@ use crate::utils::overall_value::OverallValue;
 //
 //=======================================================================//
 
-/// A checkbox that returns whever the value was changed.
+/// A checkbox that returns whether the value was changed.
 pub(in crate::map::editor) struct CheckBox;
 
 impl CheckBox
 {
-    /// Shows a checkbox and returns whever it was toggled after being clicked.
+    /// Shows a checkbox and returns whether it was toggled after being clicked.
     /// `f` determines how the boolean on/off is generated from `value`.
     #[inline]
     #[must_use]

--- a/hill_vacuum_lib/src/map/editor/state/ui/manual.rs
+++ b/hill_vacuum_lib/src/map/editor/state/ui/manual.rs
@@ -167,7 +167,7 @@ impl Manual
                      be displaced independently of the brush surface.\nBrushes can also be \
                      assigned a path that describes how it moves in the bidimensional space and \
                      that can be edited with the Path tool.\nFinally, brushes have a built-in \
-                     property, collision, which determines whever they should represent a \
+                     property, collision, which determines whether they should represent a \
                      clipping surface or not. It can be edited in the properties window."
                 ),
                 (
@@ -203,7 +203,7 @@ impl Manual
                      i8, i16, i32, i64, i128, f32, f64, and String.\n\n!!! If a saved map \
                      contains properties that differ in type and/or name from the ones defined in \
                      the aforementioned resources, a warning window will appear on screen when \
-                     trying to load the .hv file, asking whever you'd like to use the app or map \
+                     trying to load the .hv file, asking whether you'd like to use the app or map \
                      ones."
                 ),
                 (

--- a/hill_vacuum_lib/src/map/editor/state/ui/mod.rs
+++ b/hill_vacuum_lib/src/map/editor/state/ui/mod.rs
@@ -145,10 +145,10 @@ pub(in crate::map::editor::state) use textures_gallery;
 //
 //=======================================================================//
 
-/// A trait to know whever an UI element has lost focus by the standards required by the editor.
+/// A trait to know whether an UI element has lost focus by the standards required by the editor.
 pub(in crate::map::editor::state) trait ActuallyLostFocus
 {
-    /// Whever an UI element has lost focus by the standards required by the editor.
+    /// Whether an UI element has lost focus by the standards required by the editor.
     #[must_use]
     fn actually_lost_focus(&self) -> bool;
 }
@@ -175,7 +175,7 @@ impl ActuallyLostFocus for egui::Response
 /// A trait to know if an UI element is being interacted with.
 pub(in crate::map::editor::state) trait Interacting
 {
-    /// Whever the UI element is being interacted with.
+    /// Whether the UI element is being interacted with.
     #[must_use]
     fn interacting(&self) -> bool;
 }
@@ -274,7 +274,7 @@ pub(in crate::map::editor::state) enum Command
 
 impl Command
 {
-    /// Returns whever `self` represents a command that changes the entities in the map.
+    /// Returns whether `self` represents a command that changes the entities in the map.
     #[inline]
     #[must_use]
     pub const fn world_edit(self) -> bool
@@ -324,7 +324,7 @@ impl WindowCloser
         id
     }
 
-    /// Checks whever a UI window should be closed.
+    /// Checks whether a UI window should be closed.
     #[inline]
     fn check_window_close(
         layer_ids: impl ExactSizeIterator<Item = egui::LayerId>,
@@ -482,7 +482,7 @@ impl ToolsButtons
 #[must_use]
 pub(in crate::map::editor::state) struct Interaction
 {
-    /// Whever the UI is currently being hovered
+    /// Whether the UI is currently being hovered
     pub hovered: bool,
     /// A command to be executed.
     pub command: Command

--- a/hill_vacuum_lib/src/map/editor/state/ui/overall_value_field.rs
+++ b/hill_vacuum_lib/src/map/editor/state/ui/overall_value_field.rs
@@ -23,11 +23,11 @@ use crate::{
 #[derive(Default, Clone, Copy)]
 pub(in crate::map::editor::state) struct Response
 {
-    /// Whever the UI element has focus.
+    /// Whether the UI element has focus.
     pub has_focus:     bool,
-    /// Whever the UI element is being interacted with.
+    /// Whether the UI element is being interacted with.
     pub interacting:   bool,
-    /// Whever the value was changed.
+    /// Whether the value was changed.
     pub value_changed: bool
 }
 

--- a/hill_vacuum_lib/src/map/editor/state/ui/settings_window.rs
+++ b/hill_vacuum_lib/src/map/editor/state/ui/settings_window.rs
@@ -43,7 +43,7 @@ impl BindEdit
     /// The blink on string.
     const BLINK_ON: &'static str = "_";
 
-    /// Whever a bind is being edited.
+    /// Whether a bind is being edited.
     #[inline]
     #[must_use]
     const fn being_edited(&self) -> bool { matches!(self, Self::Some(..)) }

--- a/hill_vacuum_lib/src/map/editor/state/ui/texture_editor/animation_editor/mod.rs
+++ b/hill_vacuum_lib/src/map/editor/state/ui/texture_editor/animation_editor/mod.rs
@@ -574,13 +574,13 @@ pub(in crate::map::editor::state::ui) struct AnimationEditor
     animation:                UiOverallAnimation,
     /// The target of the animation editing.
     pub target:               Target,
-    /// Whever a texture animation update was scheduled.
+    /// Whether a texture animation update was scheduled.
     update_texture_animation: bool
 }
 
 impl AnimationEditor
 {
-    /// Whever the animation editor is open.
+    /// Whether the animation editor is open.
     #[inline]
     #[must_use]
     pub const fn is_open(&self) -> bool { !matches!(self.target, Target::None) }
@@ -593,7 +593,7 @@ impl AnimationEditor
     #[inline]
     pub fn open(&mut self, target: Target) { self.target = target; }
 
-    /// Whever a texture can be added to a list animation by clicking on a texture in the preview
+    /// Whether a texture can be added to a list animation by clicking on a texture in the preview
     /// gallery.
     #[inline]
     #[must_use]
@@ -619,7 +619,7 @@ impl AnimationEditor
         }
     }
 
-    /// Whever the texture override is set.
+    /// Whether the texture override is set.
     #[inline]
     #[must_use]
     pub const fn has_override(&self) -> bool { matches!(self.target, Target::Texture(Some(_))) }
@@ -724,7 +724,7 @@ impl AnimationEditor
         };
     }
 
-    /// Checks whever the sprites are within bounds.
+    /// Checks whether the sprites are within bounds.
     #[inline]
     #[must_use]
     fn check_sprites_within_bounds(
@@ -1032,7 +1032,7 @@ impl AnimationEditor
                     ui.set_height(SETTING_HEIGHT);
 
                     animation_pick(ui, |[none, list, atlas]| {
-                        /// Checks whever an animation change is valid.
+                        /// Checks whether an animation change is valid.
                         #[inline]
                         fn check_animation_change(
                             drawing_resources: &DrawingResources,

--- a/hill_vacuum_lib/src/map/editor/state/ui/texture_editor/mod.rs
+++ b/hill_vacuum_lib/src/map/editor/state/ui/texture_editor/mod.rs
@@ -950,7 +950,7 @@ const fn no_clamp(value: f32, _: f32) -> f32 { value }
 
 //=======================================================================//
 
-/// Shows a delete button and returns whever it was pressed.
+/// Shows a delete button and returns whether it was pressed.
 #[inline]
 #[must_use]
 fn delete_button(ui: &mut egui::Ui) -> bool

--- a/hill_vacuum_lib/src/map/editor/state/ui/tooltip.rs
+++ b/hill_vacuum_lib/src/map/editor/state/ui/tooltip.rs
@@ -22,7 +22,7 @@ pub(in crate::map::editor::state::ui) struct Tooltip
     spawn_time: Option<f32>,
     /// The last recorded cursor position.
     cursor_pos: egui::Pos2,
-    /// Whever the tooltip is open.
+    /// Whether the tooltip is open.
     open:       bool
 }
 

--- a/hill_vacuum_lib/src/map/editor/state/ui/window.rs
+++ b/hill_vacuum_lib/src/map/editor/state/ui/window.rs
@@ -17,7 +17,7 @@ use crate::utils::misc::Toggle;
 #[derive(Default)]
 pub(in crate::map::editor::state::ui) struct Window
 {
-    /// Whever the window is open.
+    /// Whether the window is open.
     open: bool,
     /// The [`LayerId`] of the window, if it is open.
     id:   Option<egui::LayerId>
@@ -64,7 +64,7 @@ impl Window
         }
     }
 
-    /// Whever the window is open.
+    /// Whether the window is open.
     #[inline(always)]
     #[must_use]
     pub const fn is_open(&self) -> bool { self.open }
@@ -73,8 +73,8 @@ impl Window
     #[inline(always)]
     pub fn open(&mut self) { self.open = true; }
 
-    /// Checks whever the window should be opened.
-    /// Returns whever it is currently open.
+    /// Checks whether the window should be opened.
+    /// Returns whether it is currently open.
     #[inline]
     #[must_use]
     pub fn check_open(&mut self, keys_pressed: bool) -> bool

--- a/hill_vacuum_lib/src/map/indexed_map.rs
+++ b/hill_vacuum_lib/src/map/indexed_map.rs
@@ -71,12 +71,12 @@ where
     //==============================================================
     // Info
 
-    /// Whever there are no elements.
+    /// Whether there are no elements.
     #[inline]
     #[must_use]
     pub fn is_empty(&self) -> bool { self.vec.is_empty() }
 
-    /// Whever there are no elements.
+    /// Whether there are no elements.
     #[inline]
     #[must_use]
     pub fn len(&self) -> usize { self.vec.len() }

--- a/hill_vacuum_lib/src/map/mod.rs
+++ b/hill_vacuum_lib/src/map/mod.rs
@@ -99,7 +99,7 @@ const TOOLTIP_OFFSET: egui::Vec2 = egui::Vec2::new(0f32, -12.5);
 /// A trait to determine wherever an entity fits within the map's bounds.
 pub trait OutOfBounds
 {
-    /// Whever the entity fits within the map bounds.
+    /// Whether the entity fits within the map bounds.
     #[must_use]
     fn out_of_bounds(&self) -> bool;
 }

--- a/hill_vacuum_lib/src/map/mod.rs
+++ b/hill_vacuum_lib/src/map/mod.rs
@@ -252,7 +252,7 @@ impl Plugin for MapEditorPlugin
             .insert_non_send_resource(unsafe { Editor::placeholder() })
             .insert_state(TextureLoadingProgress::default())
             .insert_resource(ClearColor(Color::Clear.default_bevy_color()))
-            .insert_resource(WinitSettings::default())
+            .insert_resource(WinitSettings::desktop_app())
             .init_resource::<TextureLoader>()
             // Setup
             .add_systems(PostStartup, initialize)

--- a/hill_vacuum_lib/src/map/path/mod.rs
+++ b/hill_vacuum_lib/src/map/path/mod.rs
@@ -366,11 +366,11 @@ pub(in crate::map) trait Moving: EntityId + EntityCenter
     #[must_use]
     fn path(&self) -> Option<&Path>;
 
-    /// Whever the entity has a [`Path`].
+    /// Whether the entity has a [`Path`].
     #[must_use]
     fn has_path(&self) -> bool;
 
-    /// Whever the entity could have a [`Path`].
+    /// Whether the entity could have a [`Path`].
     #[must_use]
     fn possible_moving(&self) -> bool;
 
@@ -386,7 +386,7 @@ pub(in crate::map) trait Moving: EntityId + EntityCenter
         calc_path_hull(self.path().unwrap(), self.center()).into()
     }
 
-    /// Whever the [`Hull`] encompassing the nodes of the [`Path`] are out of bounds if the entity
+    /// Whether the [`Hull`] encompassing the nodes of the [`Path`] are out of bounds if the entity
     /// has center at `center`.
     #[inline]
     fn path_hull_out_of_bounds(&self, center: Vec2) -> bool
@@ -408,7 +408,7 @@ pub(in crate::map) trait Moving: EntityId + EntityCenter
         self.path().unwrap().overall_selected_nodes_movement()
     }
 
-    /// Whever the selected nodes of the [`Path`] can be legally moved by `delta`.
+    /// Whether the selected nodes of the [`Path`] can be legally moved by `delta`.
     /// # Panics
     /// Panics if the entity has no [`Path`].
     #[inline]
@@ -428,7 +428,7 @@ pub(in crate::map) trait Moving: EntityId + EntityCenter
             .nearby_nodes(cursor_pos, self.center(), camera_scale)
     }
 
-    /// Whever the selected nodes of the [`Path`] can be legally deleted.
+    /// Whether the selected nodes of the [`Path`] can be legally deleted.
     /// # Panics
     /// Panics if the entity has no [`Path`].
     #[inline]
@@ -601,7 +601,7 @@ pub(in crate::map) trait EditPath: EntityId + Moving
     #[must_use]
     fn exclusively_select_path_nodes_in_range(&mut self, range: &Hull) -> Option<HvVec<u8>>;
 
-    /// Tries to insert a [`Node`] with position `cursor_pos` at `index`, returns whever the
+    /// Tries to insert a [`Node`] with position `cursor_pos` at `index`, returns whether the
     /// operation was successfull.
     /// # Panics
     /// Panics if the entity has no [`Path`].
@@ -848,7 +848,7 @@ pub(in crate::map) struct NodesMove
 
 impl NodesMove
 {
-    /// Whever any vertexes were merged.
+    /// Whether any vertexes were merged.
     #[inline]
     #[must_use]
     pub fn has_merged_vertexes(&self) -> bool { !self.merged.is_empty() }
@@ -1748,7 +1748,7 @@ impl Path
         NodesWorldMut::new(&mut self.nodes, center)
     }
 
-    /// Whever the [`Node`]s of the [`Path`] are valid.
+    /// Whether the [`Node`]s of the [`Path`] are valid.
     #[inline]
     #[must_use]
     fn nodes_valid(&self) -> bool
@@ -1759,7 +1759,7 @@ impl Path
             .all(|[a, b]| !a.pos().around_equal_narrow(&b.pos()))
     }
 
-    /// Whever the path is valid.
+    /// Whether the path is valid.
     #[inline]
     #[must_use]
     fn valid(&self) -> bool
@@ -2004,7 +2004,7 @@ impl Path
     //==============================================================
     // Insert / Remove
 
-    /// Whever inserting a new [`Node`] with position `pos` at `index` creates a valid [`Path`].
+    /// Whether inserting a new [`Node`] with position `pos` at `index` creates a valid [`Path`].
     #[inline]
     #[must_use]
     fn is_node_at_index_valid(&self, pos: Vec2, index: usize, center: Vec2) -> bool
@@ -2079,7 +2079,7 @@ impl Path
         assert!(self.valid(), "remove_nodes_at_indexes generated an invalid Path.");
     }
 
-    /// Checks whever deleting the selected [`Node`]s would create a valid path.
+    /// Checks whether deleting the selected [`Node`]s would create a valid path.
     #[inline]
     pub(in crate::map) fn check_selected_nodes_deletion(&self) -> NodesDeletionResult
     {
@@ -2198,7 +2198,7 @@ impl Path
         }
     }
 
-    /// Toggles the selection status of the [`Node`] at index `index` and returns whever it was
+    /// Toggles the selection status of the [`Node`] at index `index` and returns whether it was
     /// selected.
     #[inline]
     pub(in crate::map) fn toggle_node_at_index(&mut self, index: usize) -> bool
@@ -2209,7 +2209,7 @@ impl Path
         selected
     }
 
-    /// Checks whever there is a [`Node`] nearby `cursor_pos` and selects it if not already
+    /// Checks whether there is a [`Node`] nearby `cursor_pos` and selects it if not already
     /// selected. Returns a [`NodeSelectionResult`] describing the outcome.
     #[inline]
     pub(in crate::map) fn exclusively_select_path_node_at_index(
@@ -2346,7 +2346,7 @@ impl Path
         assert!(self.valid(), "move_nodes_at_indexes generated an invalid Path.");
     }
 
-    /// Checks whever moving the selected [`Node`]s by `delta` generates a valid path.
+    /// Checks whether moving the selected [`Node`]s by `delta` generates a valid path.
     /// Returns a [`NodesMoveResult`] describing the outcome.
     #[inline]
     pub(in crate::map) fn check_selected_nodes_move(&self, delta: Vec2) -> NodesMoveResult

--- a/hill_vacuum_lib/src/map/path/nodes.rs
+++ b/hill_vacuum_lib/src/map/path/nodes.rs
@@ -412,7 +412,7 @@ pub(in crate::map) struct NodesInsertionIter<'a>
     new_node:          NodeWorld,
     /// The index where the new [`Node`] will be inserted.
     new_node_index:    usize,
-    /// Whever the iterator has already returned the position of the new [`Node`] being inserted.
+    /// Whether the iterator has already returned the position of the new [`Node`] being inserted.
     new_node_returned: usize,
     /// The index of the next [`Node`] of `slice` to iterate.
     i:                 usize,

--- a/hill_vacuum_lib/src/map/path/overall_values.rs
+++ b/hill_vacuum_lib/src/map/path/overall_values.rs
@@ -88,7 +88,7 @@ impl OverallMovement
         }
     }
 
-    /// Whever `self` was fed any values.
+    /// Whether `self` was fed any values.
     #[inline]
     #[must_use]
     pub const fn is_some(&self) -> bool { self.max_speed.is_some() }

--- a/hill_vacuum_lib/src/map/properties.rs
+++ b/hill_vacuum_lib/src/map/properties.rs
@@ -205,7 +205,7 @@ impl Value
     pub(in crate::map) const BOOL_DISCRIMINANT: Discriminant<Self> =
         std::mem::discriminant(&Self::Bool(true));
 
-    /// Whever `self` and `other` have the same [`Discriminant`].
+    /// Whether `self` and `other` have the same [`Discriminant`].
     #[inline]
     #[must_use]
     pub(in crate::map) fn eq_discriminant(&self, other: &Self) -> bool

--- a/hill_vacuum_lib/src/map/selectable_vector.rs
+++ b/hill_vacuum_lib/src/map/selectable_vector.rs
@@ -94,7 +94,7 @@ pub struct SelectableVector
 {
     /// The vector.
     pub vec:      Vec2,
-    /// Whever it is selected or not.
+    /// Whether it is selected or not.
     pub selected: bool
 }
 

--- a/hill_vacuum_lib/src/map/thing/catalog.rs
+++ b/hill_vacuum_lib/src/map/thing/catalog.rs
@@ -189,7 +189,7 @@ impl ThingsCatalog
     //==============================================================
     // Info
 
-    /// Whever the [`ThingsCatalog`] contains any [`Thing`].
+    /// Whether the [`ThingsCatalog`] contains any [`Thing`].
     #[inline]
     #[must_use]
     pub fn is_empty(&self) -> bool { self.things.is_empty() }

--- a/hill_vacuum_lib/src/map/thing/mod.rs
+++ b/hill_vacuum_lib/src/map/thing/mod.rs
@@ -512,7 +512,7 @@ impl ThingInstance
     #[inline]
     pub const fn properties(&self) -> &Properties { &self.data.properties }
 
-    /// Whever the bounding box contains the point `p`.
+    /// Whether the bounding box contains the point `p`.
     #[inline]
     #[must_use]
     pub fn contains_point(&self, p: Vec2) -> bool { self.data.hull.contains_point(p) }
@@ -523,7 +523,7 @@ impl ThingInstance
     #[inline]
     fn path_mut(&mut self) -> &mut Path { self.data.path.as_mut().unwrap() }
 
-    /// Check whever changing the [`ThingId`] would cause `self` to have an out of bounds bounding
+    /// Check whether changing the [`ThingId`] would cause `self` to have an out of bounds bounding
     /// box.
     #[inline]
     #[must_use]
@@ -538,7 +538,7 @@ impl ThingInstance
     #[must_use]
     pub fn set_thing(&mut self, thing: &Thing) -> Option<ThingId> { self.data.set_thing(thing) }
 
-    /// Check whever `self` can be moved without being out of bounds.
+    /// Check whether `self` can be moved without being out of bounds.
     #[inline]
     #[must_use]
     pub fn check_move(&self, delta: Vec2) -> bool

--- a/hill_vacuum_lib/src/utils/hull.rs
+++ b/hill_vacuum_lib/src/utils/hull.rs
@@ -520,7 +520,7 @@ impl Hull
         (self.left..=self.right, self.bottom..=self.top)
     }
 
-    /// Whever the [`Hull`] contains `p`.
+    /// Whether the [`Hull`] contains `p`.
     #[inline]
     #[must_use]
     pub fn contains_point(&self, p: Vec2) -> bool
@@ -529,7 +529,7 @@ impl Hull
         range.0.contains(&p.x) && range.1.contains(&p.y)
     }
 
-    /// Whever the [`Hull`] contains `other`.
+    /// Whether the [`Hull`] contains `other`.
     #[inline]
     #[must_use]
     pub fn contains_hull(&self, other: &Self) -> bool
@@ -542,7 +542,7 @@ impl Hull
             range.1.contains(&other.top)
     }
 
-    /// Whever the [`Hull`] overlaps `other`.
+    /// Whether the [`Hull`] overlaps `other`.
     #[inline]
     #[must_use]
     pub fn overlaps(&self, other: &Self) -> bool
@@ -553,7 +553,7 @@ impl Hull
             self.bottom < other.top
     }
 
-    /// Whever the [`Hull`] intersects another one.
+    /// Whether the [`Hull`] intersects another one.
     #[inline]
     #[must_use]
     pub fn intersects(&self, other: &Self) -> bool
@@ -916,7 +916,7 @@ impl Hull
         let opposite_vertex = self.corner_vertex(selected_corner.opposite_corner());
         let mut new_selected_corner = *selected_corner;
 
-        /// Checks whever the scaling process leads to a flip.
+        /// Checks whether the scaling process leads to a flip.
         macro_rules! check_flips {
             ($funcs:expr) => {
                 for func in $funcs

--- a/hill_vacuum_lib/src/utils/iterators.rs
+++ b/hill_vacuum_lib/src/utils/iterators.rs
@@ -211,7 +211,7 @@ impl<T, const N: usize> Filters<T, N>
 where
     T: PartialEq + Eq
 {
-    /// Returns a value which represents whever `value` should be filtered.
+    /// Returns a value which represents whether `value` should be filtered.
     #[inline]
     #[must_use]
     fn filter(&mut self, value: &T) -> FilterResult

--- a/hill_vacuum_lib/src/utils/math/lines_and_segments.rs
+++ b/hill_vacuum_lib/src/utils/math/lines_and_segments.rs
@@ -157,12 +157,12 @@ pub fn segments_intersection(s_1: &[Vec2; 2], s_2: &[Vec2; 2]) -> Option<(Vec2, 
 
 //=======================================================================//
 
-/// Whever `p` is on the segment `s`.
+/// Whether `p` is on the segment `s`.
 #[inline]
 #[must_use]
 pub fn is_point_on_segment(s: &[Vec2; 2], p: Vec2) -> bool
 {
-    /// The epsilon used to determine whever the point can reasonably considered on the segment.
+    /// The epsilon used to determine whether the point can reasonably considered on the segment.
     const POINT_ON_LINE_EPSILON: f32 = 1f32 / 16f32;
 
     // This is the only method that has proven itself to be reliable.
@@ -181,7 +181,7 @@ pub fn line_point_product(l: &[Vec2; 2], p: Vec2) -> f32
 
 //=======================================================================//
 
-/// Whever `p` is inside the clip edge of `l`.
+/// Whether `p` is inside the clip edge of `l`.
 #[inline]
 #[must_use]
 pub fn is_point_inside_clip_edge(l: &[Vec2; 2], p: Vec2) -> bool { line_point_product(l, p) > 0f32 }

--- a/hill_vacuum_lib/src/utils/math/mod.rs
+++ b/hill_vacuum_lib/src/utils/math/mod.rs
@@ -17,14 +17,14 @@ use bevy::prelude::Vec2;
 //
 //=======================================================================//
 
-/// A trait to determine whever two objects are equal within a certain error margin.
+/// A trait to determine whether two objects are equal within a certain error margin.
 pub trait AroundEqual
 {
-    /// Whever `self` and `other` are equal within a somewhat loose margin.
+    /// Whether `self` and `other` are equal within a somewhat loose margin.
     #[must_use]
     fn around_equal(&self, other: &Self) -> bool;
 
-    /// Whever `self` and `other` are equal within a very tight margin.
+    /// Whether `self` and `other` are equal within a very tight margin.
     #[must_use]
     fn around_equal_narrow(&self, other: &Self) -> bool;
 }

--- a/hill_vacuum_lib/src/utils/math/points.rs
+++ b/hill_vacuum_lib/src/utils/math/points.rs
@@ -164,7 +164,7 @@ pub fn are_vxs_ccw(vxs: &[Vec2; 3]) -> bool
 
 //=======================================================================//
 
-/// Whever the polygon described by the vertexes `vxs` is convex.
+/// Whether the polygon described by the vertexes `vxs` is convex.
 /// Assumes `vxs` are clockwise sorted.
 #[inline]
 #[must_use]

--- a/hill_vacuum_lib/src/utils/misc.rs
+++ b/hill_vacuum_lib/src/utils/misc.rs
@@ -341,10 +341,10 @@ impl Toggle for f32
 
 //=======================================================================//
 
-/// A trait to determine whever a point is inside the UI rectangle highlight of a point.
+/// A trait to determine whether a point is inside the UI rectangle highlight of a point.
 pub trait PointInsideUiHighlight
 {
-    /// Whever `p` is inside the area of `self` while accounting for `camera_scale`.
+    /// Whether `p` is inside the area of `self` while accounting for `camera_scale`.
     #[must_use]
     fn is_point_inside_ui_highlight(&self, p: Vec2, camera_scale: f32) -> bool;
 }
@@ -371,7 +371,7 @@ pub struct Blinker
 {
     /// The leftover amount of time it must pulse.
     time:     f32,
-    /// Whever the pulse is on or off.
+    /// Whether the pulse is on or off.
     onoff:    bool,
     /// The duration of the pulsation.
     interval: f32
@@ -390,7 +390,7 @@ impl Blinker
         }
     }
 
-    /// Whever the [`Blinker`] is in the on state.
+    /// Whether the [`Blinker`] is in the on state.
     #[inline]
     #[must_use]
     pub const fn on(&self) -> bool { self.onoff }

--- a/hill_vacuum_lib/src/utils/overall_value.rs
+++ b/hill_vacuum_lib/src/utils/overall_value.rs
@@ -17,7 +17,7 @@ use super::misc::ReplaceValues;
 /// A trait for types representing the overall value of a list of elements.
 pub trait OverallValueInterface<T>
 {
-    /// Whever `self` now represents a non uniform value.
+    /// Whether `self` now represents a non uniform value.
     #[must_use]
     fn is_not_uniform(&self) -> bool;
 
@@ -129,7 +129,7 @@ impl<T: PartialEq + Clone> OverallValue<T>
     #[inline]
     pub const fn new(value: T) -> Self { Self::Uniform(value) }
 
-    /// Whever `self` described at least one value.
+    /// Whether `self` described at least one value.
     #[inline]
     #[must_use]
     pub const fn is_some(&self) -> bool { !matches!(self, Self::None) }


### PR DESCRIPTION
Hi @IvoryDuke 

This work of yours is thoroughly impressive and I have learned a lot from studying it. 
I will use some of the concepts for my own (non-game) editor. 

I noticed that there is a panic every time I do the shatter operation. I am not sure if I am doing something wrong, or if its an issue with the shatter tool itself or just the item selection logic. 

This MR does 2 things:
1) Fixes spelling mistake "whever" -> "whether"
2) In item_selector.rs:
```
@@ -255,8 +255,12 @@ where
             }
         };

-        let value = Some(self.items[self.depth]);
-        self.previous = value;
-        value
+        if let Position::None = self.depth {
+            None
+        } else {
+            let value = Some(self.items[self.depth]);
+            self.previous = value;
+            value
+        }
```

If you want me to split it into two MR's I can do that. 


