### PR TITLE
fix item-selector panic

### DIFF
--- a/src/map/editor/state/core/item_selector.rs
+++ b/src/map/editor/state/core/item_selector.rs
@@ -219,45 +219,51 @@ where
 
         self.items.sort(manager);
 
-        if let Some(prev) = self.previous
+        match self.previous
         {
-            self.depth = self.items.position(prev);
+            Some(prev) =>
+            {
+                self.depth = self.items.position(prev);
 
-            if matches!(self.depth, Position::None)
-            {
-                self.previous = None;
-            }
-            else if inputs.tab.just_pressed()
-            {
-                match &mut self.depth
+                if matches!(self.depth, Position::None)
                 {
-                    Position::None => panic!(),
-                    Position::Selected(idx) =>
+                    self.previous = None;
+                    self.update_previous_value();
+                }
+                else if inputs.tab.just_pressed()
+                {
+                    match &mut self.depth
                     {
-                        *idx = next(*idx, self.items.selected.len());
-                    },
-                    Position::NonSelected(idx) =>
-                    {
-                        *idx = next(*idx, self.items.non_selected.len());
-                    }
-                };
-            }
-        }
-
-        if self.previous.is_none()
-        {
-            self.depth = if self.items.selected.is_empty()
-            {
-                assert!(!self.items.non_selected.is_empty(), "No non selected items.");
-                Position::NonSelected(0)
-            }
-            else
-            {
-                Position::Selected(0)
-            };
+                        Position::None => panic!(),
+                        Position::Selected(idx) =>
+                        {
+                            *idx = next(*idx, self.items.selected.len());
+                        },
+                        Position::NonSelected(idx) =>
+                        {
+                            *idx = next(*idx, self.items.non_selected.len());
+                        }
+                    };
+                }
+            },
+            None => self.update_previous_value()
         }
 
         self.previous = Some(self.items[self.depth]);
         self.previous
+    }
+
+    #[inline]
+    fn update_previous_value(&mut self)
+    {
+        self.depth = if self.items.selected.is_empty()
+        {
+            assert!(!self.items.non_selected.is_empty(), "No non selected items.");
+            Position::NonSelected(0)
+        }
+        else
+        {
+            Position::Selected(0)
+        };
     }
 }

--- a/src/map/editor/state/core/item_selector.rs
+++ b/src/map/editor/state/core/item_selector.rs
@@ -254,9 +254,12 @@ where
                 };
             }
         };
-        if let Position::None = self.depth {
+        if let Position::None = self.depth
+        {
             None
-        } else {
+        }
+        else
+        {
             let value = Some(self.items[self.depth]);
             self.previous = value;
             value

--- a/src/map/editor/state/core/item_selector.rs
+++ b/src/map/editor/state/core/item_selector.rs
@@ -219,50 +219,45 @@ where
 
         self.items.sort(manager);
 
-        match self.previous
+        if let Some(prev) = self.previous
         {
-            Some(prev) =>
-            {
-                self.depth = self.items.position(prev);
+            self.depth = self.items.position(prev);
 
-                if inputs.tab.just_pressed()
-                {
-                    match &mut self.depth
-                    {
-                        Position::None => panic!(),
-                        Position::Selected(idx) =>
-                        {
-                            *idx = next(*idx, self.items.selected.len());
-                        },
-                        Position::NonSelected(idx) =>
-                        {
-                            *idx = next(*idx, self.items.non_selected.len());
-                        }
-                    };
-                }
-            },
-            None =>
+            if matches!(self.depth, Position::None)
             {
-                self.depth = if self.items.selected.is_empty()
+                self.previous = None;
+            }
+            else if inputs.tab.just_pressed()
+            {
+                match &mut self.depth
                 {
-                    assert!(!self.items.non_selected.is_empty(), "No non selected items.");
-                    Position::NonSelected(0)
-                }
-                else
-                {
-                    Position::Selected(0)
+                    Position::None => panic!(),
+                    Position::Selected(idx) =>
+                    {
+                        *idx = next(*idx, self.items.selected.len());
+                    },
+                    Position::NonSelected(idx) =>
+                    {
+                        *idx = next(*idx, self.items.non_selected.len());
+                    }
                 };
             }
-        };
-        if let Position::None = self.depth
-        {
-            None
         }
-        else
+
+        if self.previous.is_none()
         {
-            let value = Some(self.items[self.depth]);
-            self.previous = value;
-            value
+            self.depth = if self.items.selected.is_empty()
+            {
+                assert!(!self.items.non_selected.is_empty(), "No non selected items.");
+                Position::NonSelected(0)
+            }
+            else
+            {
+                Position::Selected(0)
+            };
         }
+
+        self.previous = Some(self.items[self.depth]);
+        self.previous
     }
 }

--- a/src/map/editor/state/core/item_selector.rs
+++ b/src/map/editor/state/core/item_selector.rs
@@ -254,9 +254,12 @@ where
                 };
             }
         };
-
-        let value = Some(self.items[self.depth]);
-        self.previous = value;
-        value
+        if let Position::None = self.depth {
+            None
+        } else {
+            let value = Some(self.items[self.depth]);
+            self.previous = value;
+            value
+        }
     }
 }


### PR DESCRIPTION
I noticed that there is a panic every time I do the shatter operation. I am not sure if I am doing something wrong, or if its an issue with the shatter tool itself or just the item selection logic.

Description:

Fix item selector logic that causes a panic. (although likely not the route cause of the issue)
Related: https://github.com/IvoryDuke/HillVacuum/pull/5

